### PR TITLE
build doc on pull request but don't deploy

### DIFF
--- a/.github/workflows/deploy-docusaurus.yml
+++ b/.github/workflows/deploy-docusaurus.yml
@@ -1,6 +1,8 @@
 name: deploy-docusaurus
 
 on:
+  pull_request:
+    branches: [documentation]
   push:
     branches: [documentation]
 
@@ -26,7 +28,7 @@ jobs:
           npm install
           npm run build
       - name: Deploy to GitHub Pages
-        if: success()
+        if: success() && github.event_name != 'pull_request'
         uses: crazy-max/ghaction-github-pages@v2
         with:
           target_branch: gh-pages


### PR DESCRIPTION
For pull-request, build the documentation. This will catch all errors before merging the PR.

For push-request, build and deploy the documentation. This will deploy the pages on `gh-pages` channel. 

Signed-off-by: senthil <cendhu@gmail.com>