### PR TITLE
TLS support for comm

### DIFF
--- a/config/ca_config.go
+++ b/config/ca_config.go
@@ -1,0 +1,56 @@
+// Copyright IBM Corp. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path"
+
+	"github.com/hyperledger-labs/orion-server/internal/fileops"
+	"github.com/pkg/errors"
+)
+
+// CAConfiguration holds the path to the x509 certificates of the certificate authorities who issues all certificates.
+type CAConfiguration struct {
+	RootCACertsPath         []string
+	IntermediateCACertsPath []string
+}
+
+func (c *CAConfiguration) WriteBundle(filePath string) error {
+	dirName := path.Dir(filePath)
+	err := fileops.CreateDir(dirName)
+	if err != nil {
+		return errors.Wrapf(err, "error creating directory: %s", dirName)
+	}
+
+	bundleFile, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return errors.Wrapf(err, "error while opening file: %s", filePath)
+	}
+	defer bundleFile.Close()
+
+	for _, caFileName := range c.RootCACertsPath {
+		caBytes, err := os.ReadFile(caFileName)
+		if err != nil {
+			return errors.Wrapf(err, "error while opening file: %s", filePath)
+		}
+		_, err = bundleFile.Write(caBytes)
+		if err != nil {
+			return errors.Wrapf(err, "error while writing file: %s", bundleFile.Name())
+		}
+	}
+
+	for _, caFileName := range c.IntermediateCACertsPath {
+		caBytes, err := os.ReadFile(caFileName)
+		if err != nil {
+			return errors.Wrapf(err, "error while opening file: %s", filePath)
+		}
+		_, err = bundleFile.Write(caBytes)
+		if err != nil {
+			return errors.Wrapf(err, "error while writing file: %s", bundleFile.Name())
+		}
+	}
+
+	return nil
+}

--- a/config/ca_config_test.go
+++ b/config/ca_config_test.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"github.com/hyperledger-labs/orion-server/pkg/server/testutils"
+	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"path"
+	"testing"
+)
+
+func TestCAConfiguration_WriteBundle(t *testing.T) {
+	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"user", "node"}, true)
+
+	rootCAFileName := path.Join(cryptoDir, testutils.RootCAFileName+".pem")
+	interCAFileName := path.Join(cryptoDir, testutils.IntermediateCAFileName+".pem")
+
+	caConfig := CAConfiguration{
+		RootCACertsPath:         []string{rootCAFileName},
+		IntermediateCACertsPath: []string{interCAFileName},
+	}
+
+	caFile := path.Join(cryptoDir, "node", "ca-bundle.pem")
+	err := caConfig.WriteBundle(caFile)
+	require.NoError(t, err)
+
+	bundleBytes, err := ioutil.ReadFile(caFile)
+	require.NoError(t, err)
+	require.NotNil(t, bundleBytes)
+
+	var block *pem.Block
+	for i := 0; i < 3; i++ {
+		block, bundleBytes = pem.Decode(bundleBytes)
+		if i < 2 {
+			require.NotNil(t, block)
+		} else {
+			require.Nil(t, block)
+			break
+		}
+		certRaw := block.Bytes
+		cert, err := x509.ParseCertificate(certRaw)
+		require.NoError(t, err)
+		require.NotNil(t, cert)
+		t.Logf("cert ca: %t, subject: %s, issuer: %s, serial: %v", cert.IsCA, cert.Subject, cert.Issuer, cert.SerialNumber)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -1,5 +1,6 @@
 // Copyright IBM Corp. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (
@@ -36,13 +37,15 @@ type ReplicationConf struct {
 	WALDir string
 	// SnapDir defines the directory used to store snapshots produced by the consensus algorithm.
 	SnapDir string
+	// AuxDir defines the directory used to store auxiliary and temporary files during replication.
+	AuxDir string
 	// Network defines the listen address and port used for server to server communication.
 	Network NetworkConf
 	// TLS defines TLS settings for server to server communication.
 	TLS TLSConf
 }
 
-// TLS configuration settings.
+// TLSConf holds TLS configuration settings.
 type TLSConf struct {
 	// Require server-side TLS.
 	Enabled bool

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -39,6 +39,7 @@ var expectedLocalConfig = &LocalConfiguration{
 	Replication: ReplicationConf{
 		WALDir:  "./tmp/etcdraft/wal",
 		SnapDir: "./tmp/etcdraft/snapshot",
+		AuxDir:  "./tmp/orion/auxiliary",
 		Network: NetworkConf{
 			Address: "127.0.0.1",
 			Port:    7050,

--- a/config/shared_config.go
+++ b/config/shared_config.go
@@ -85,12 +85,6 @@ type AdminConf struct {
 	CertificatePath string
 }
 
-// CAConfiguration holds the path to the x509 certificates of the certificate authorities who issues all certificates.
-type CAConfiguration struct {
-	RootCACertsPath         []string
-	IntermediateCACertsPath []string
-}
-
 // readSharedConfig reads the shared config from the file and returns it.
 func readSharedConfig(sharedConfigFile string) (*SharedConfiguration, error) {
 	if sharedConfigFile == "" {

--- a/config/testdata/config.yml
+++ b/config/testdata/config.yml
@@ -62,6 +62,9 @@ replication:
   # The directory for the Raft snapshots.
   snapDir: "./tmp/etcdraft/snapshot"
 
+  # The directory for the auxiliary files.
+  auxDir: "./tmp/orion/auxiliary"
+
   # The listen address and port for intra-cluster communication.
   # The external address (or host name) of this interface
   # must be accessible from all other servers (a.k.a. "peers"),

--- a/deployment/config-docker/config.yml
+++ b/deployment/config-docker/config.yml
@@ -62,6 +62,9 @@ replication:
   # The directory for the Raft snapshots.
   snapDir: "/var/orion-server/ledger/etcdraft/snapshot"
 
+  # The directory for the auxiliary files.
+  auxDir: "/var/orion-server/ledger/auxiliary"
+
   # The listen address and port for intra-cluster communication.
   # The external address (or host name) of this interface
   # must be accessible from all other servers (a.k.a. "peers"),

--- a/internal/bcdb/transaction_processor.go
+++ b/internal/bcdb/transaction_processor.go
@@ -122,11 +122,14 @@ func newTransactionProcessor(conf *txProcessorConfig) (*transactionProcessor, er
 		return nil, err
 	}
 
-	p.peerTransport = comm.NewHTTPTransport(&comm.Config{
+	p.peerTransport, err = comm.NewHTTPTransport(&comm.Config{
 		LocalConf:    localConfig,
 		Logger:       conf.logger,
 		LedgerReader: conf.blockStore,
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	clusterConfig, _, err := conf.db.GetConfig()
 	if err != nil {

--- a/internal/comm/httptransport_catchup_test.go
+++ b/internal/comm/httptransport_catchup_test.go
@@ -11,11 +11,11 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger-labs/orion-server/internal/comm"
 	"github.com/hyperledger-labs/orion-server/internal/comm/mocks"
 	"github.com/hyperledger-labs/orion-server/pkg/logger"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
-	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,14 +30,14 @@ func TestHTTPTransport_CatchupService(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	localConfigs, sharedConfig := newTestSetup(1)
+	localConfigs, sharedConfig := newTestSetup(t, 1)
 
 	ledger1 := &memLedger{}
 	for n := uint64(1); n < 6; n++ {
 		ledger1.Append(&types.Block{Header: &types.BlockHeader{BaseHeader: &types.BlockHeaderBase{Number: n}}})
 	}
 	cl1 := &mocks.ConsensusListener{}
-	tr1 := comm.NewHTTPTransport(&comm.Config{
+	tr1, _ := comm.NewHTTPTransport(&comm.Config{
 		LocalConf:    localConfigs[0],
 		Logger:       lg,
 		LedgerReader: ledger1,

--- a/internal/comm/httptransport_test.go
+++ b/internal/comm/httptransport_test.go
@@ -5,6 +5,10 @@ package comm_test
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,26 +16,31 @@ import (
 	"github.com/hyperledger-labs/orion-server/internal/comm"
 	"github.com/hyperledger-labs/orion-server/internal/comm/mocks"
 	"github.com/hyperledger-labs/orion-server/pkg/logger"
+	"github.com/hyperledger-labs/orion-server/pkg/server/testutils"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/raft/raftpb"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestNewHTTPTransport(t *testing.T) {
 	lg, err := logger.New(&logger.Config{
-		Level:         "debug",
+		Level:         "info",
 		OutputPath:    []string{"stdout"},
 		ErrOutputPath: []string{"stderr"},
 		Encoding:      "console",
 	})
 	require.NoError(t, err)
 
-	localConfigs, sharedConfig := newTestSetup(1)
+	localConfigs, sharedConfig := newTestSetup(t, 1)
 
-	tr1 := comm.NewHTTPTransport(&comm.Config{
+	tr1, err := comm.NewHTTPTransport(&comm.Config{
 		LocalConf: localConfigs[0],
 		Logger:    lg,
 	})
+	require.NoError(t, err)
 	require.NotNil(t, tr1)
 
 	err = tr1.SetConsensusListener(&mocks.ConsensusListener{})
@@ -47,17 +56,17 @@ func TestNewHTTPTransport(t *testing.T) {
 
 func TestHTTPTransport_SendConsensus(t *testing.T) {
 	lg, err := logger.New(&logger.Config{
-		Level:         "debug",
+		Level:         "info",
 		OutputPath:    []string{"stdout"},
 		ErrOutputPath: []string{"stderr"},
 		Encoding:      "console",
 	})
 	require.NoError(t, err)
 
-	localConfigs, sharedConfig := newTestSetup(2)
+	localConfigs, sharedConfig := newTestSetup(t, 2)
 
 	cl1 := &mocks.ConsensusListener{}
-	tr1 := comm.NewHTTPTransport(&comm.Config{
+	tr1, _ := comm.NewHTTPTransport(&comm.Config{
 		LocalConf: localConfigs[0],
 		Logger:    lg,
 	})
@@ -68,7 +77,7 @@ func TestHTTPTransport_SendConsensus(t *testing.T) {
 	require.NoError(t, err)
 
 	cl2 := &mocks.ConsensusListener{}
-	tr2 := comm.NewHTTPTransport(&comm.Config{
+	tr2, _ := comm.NewHTTPTransport(&comm.Config{
 		LocalConf: localConfigs[1],
 		Logger:    lg,
 	})
@@ -104,21 +113,323 @@ func TestHTTPTransport_SendConsensus(t *testing.T) {
 	)
 }
 
-func newTestSetup(numServers int) ([]*config.LocalConfiguration, *types.ClusterConfig) {
+// Scenario: both sides enable TLS.
+// Messages arrive.
+func TestHTTPTransport_SendConsensus_TLS(t *testing.T) {
+	lg, err := logger.New(&logger.Config{
+		Level:         "info",
+		OutputPath:    []string{"stdout"},
+		ErrOutputPath: []string{"stderr"},
+		Encoding:      "console",
+	})
+	require.NoError(t, err)
+
+	localConfigs, sharedConfig := newTestSetup(t, 2)
+	for _, c := range localConfigs {
+		c.Replication.TLS.Enabled = true
+	}
+
+	cl1 := &mocks.ConsensusListener{}
+	tr1, err := comm.NewHTTPTransport(&comm.Config{
+		LocalConf: localConfigs[0],
+		Logger:    lg,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, tr1)
+	err = tr1.SetConsensusListener(cl1)
+	require.NoError(t, err)
+	err = tr1.UpdateClusterConfig(sharedConfig)
+	require.NoError(t, err)
+
+	cl2 := &mocks.ConsensusListener{}
+	tr2, err := comm.NewHTTPTransport(&comm.Config{
+		LocalConf: localConfigs[1],
+		Logger:    lg,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, tr1)
+	err = tr2.SetConsensusListener(cl2)
+	require.NoError(t, err)
+	err = tr2.UpdateClusterConfig(sharedConfig)
+	require.NoError(t, err)
+
+	err = tr1.Start()
+	require.NoError(t, err)
+	defer tr1.Close()
+
+	err = tr2.Start()
+	require.NoError(t, err)
+	defer tr2.Close()
+
+	tr1.SendConsensus([]raftpb.Message{{To: 2}})
+	require.Eventually(t,
+		func() bool {
+			return cl2.ProcessCallCount() == 1
+		},
+		10*time.Second, 10*time.Millisecond,
+	)
+
+	tr2.SendConsensus([]raftpb.Message{{To: 1}})
+	tr2.SendConsensus([]raftpb.Message{{To: 1}})
+	require.Eventually(t,
+		func() bool {
+			return cl1.ProcessCallCount() == 2
+		},
+		10*time.Second, 10*time.Millisecond,
+	)
+}
+
+// Scenario: one side enables TLS, the other not.
+// Messages do not arrive, nodes are reported unreachable.
+// log messages indicate that
+// - the TLS enabled side expects TLS handshakes and does not get it
+// - the unsecure side tries to use schema 'http' and gets a bad request
+func TestHTTPTransport_SendConsensus_HalfTLS(t *testing.T) {
+	// the raft log messages use fields, so we can't capture them with "zap.Hook", which does not carry the "Context".
+	loggerCore, observedLogs := observer.New(zapcore.DebugLevel)
+	observedLogger := zap.New(loggerCore).Sugar()
+	lg := &logger.SugarLogger{SugaredLogger: observedLogger}
+
+	localConfigs, sharedConfig := newTestSetup(t, 2)
+	localConfigs[0].Replication.TLS.Enabled = true
+
+	cl1 := &mocks.ConsensusListener{}
+	tr1, err := comm.NewHTTPTransport(&comm.Config{
+		LocalConf: localConfigs[0],
+		Logger:    lg,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, tr1)
+	err = tr1.SetConsensusListener(cl1)
+	require.NoError(t, err)
+	err = tr1.UpdateClusterConfig(sharedConfig)
+	require.NoError(t, err)
+
+	cl2 := &mocks.ConsensusListener{}
+	tr2, err := comm.NewHTTPTransport(&comm.Config{
+		LocalConf: localConfigs[1],
+		Logger:    lg,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, tr1)
+	err = tr2.SetConsensusListener(cl2)
+	require.NoError(t, err)
+	err = tr2.UpdateClusterConfig(sharedConfig)
+	require.NoError(t, err)
+
+	err = tr1.Start()
+	require.NoError(t, err)
+
+	err = tr2.Start()
+	require.NoError(t, err)
+
+	tr1.SendConsensus([]raftpb.Message{{To: 2}})
+	tr1.SendConsensus([]raftpb.Message{{To: 2}})
+
+	tr2.SendConsensus([]raftpb.Message{{To: 1}})
+	tr2.SendConsensus([]raftpb.Message{{To: 1}})
+	tr2.SendConsensus([]raftpb.Message{{To: 1}})
+
+	require.Eventually(t, func() bool { return cl1.ReportUnreachableCallCount() == 2 }, 5*time.Second, 100*time.Millisecond)
+	require.Eventually(t, func() bool { return cl2.ReportUnreachableCallCount() == 3 }, 5*time.Second, 100*time.Millisecond)
+
+	require.Equal(t, 0, cl1.ProcessCallCount())
+	require.Equal(t, 0, cl2.ProcessCallCount())
+
+	require.Equal(t, 0, cl1.IsIDRemovedCallCount())
+	require.Equal(t, 0, cl2.IsIDRemovedCallCount())
+
+	tr1.Close()
+	tr2.Close()
+
+	t.Log("Analyzing logs:")
+	require.True(t, observedLogs.Len() > 0)
+	failedHandshake := 0
+	failedHttp := 0
+	for _, entry := range observedLogs.All() {
+		if strings.Contains(entry.Message, "peer deactivated") {
+			ctxMap := entry.ContextMap()
+			id, ok := ctxMap["peer-id"]
+			require.True(t, ok)
+			errS, ok := ctxMap["error"]
+			require.True(t, ok)
+
+			fmt.Printf("%s | %s | %v \n", entry.Time, entry.Message, entry.ContextMap())
+			switch id {
+			case "1":
+				if strings.Contains(errS.(string), "failed to write 1 on pipeline (unexpected http status Bad Request while posting to \"http://127.0.0.1:33000/raft\")") {
+					failedHttp++
+				}
+			case "2":
+				if strings.Contains(errS.(string), "(tls: first record does not look like a TLS handshake)") {
+					failedHandshake++
+				}
+			default:
+				t.Failed()
+			}
+		}
+	}
+	require.True(t, failedHandshake > 0)
+	require.True(t, failedHttp > 0)
+}
+
+// Scenario: both sides enable TLS, but trust different CAs.
+// Messages do not arrive, nodes are reported unreachable.
+// log messages indicate that
+// - the TLS handshake fails because the certificate cannot be verified against the CA.
+func TestHTTPTransport_SendConsensus_TLS_CAMismatch(t *testing.T) {
+	// the raft log messages use fields, so we can't capture them with "zap.Hook", which does not carry the "Context".
+	loggerCore, observedLogs := observer.New(zapcore.DebugLevel)
+	observedLogger := zap.New(loggerCore).Sugar()
+	lg := &logger.SugarLogger{SugaredLogger: observedLogger}
+
+	//each setup has a different root CA
+	localConfigs1, sharedConfig1 := newTestSetup(t, 2)
+	for _, c := range localConfigs1 {
+		c.Replication.TLS.Enabled = true
+	}
+	localConfigs2, sharedConfig2 := newTestSetup(t, 2)
+	for _, c := range localConfigs2 {
+		c.Replication.TLS.Enabled = true
+	}
+
+	cl1 := &mocks.ConsensusListener{}
+	tr1, err := comm.NewHTTPTransport(&comm.Config{
+		LocalConf: localConfigs1[0],
+		Logger:    lg,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, tr1)
+	err = tr1.SetConsensusListener(cl1)
+	require.NoError(t, err)
+	err = tr1.UpdateClusterConfig(sharedConfig1)
+	require.NoError(t, err)
+
+	cl2 := &mocks.ConsensusListener{}
+	tr2, err := comm.NewHTTPTransport(&comm.Config{
+		LocalConf: localConfigs2[1],
+		Logger:    lg,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, tr1)
+	err = tr2.SetConsensusListener(cl2)
+	require.NoError(t, err)
+	err = tr2.UpdateClusterConfig(sharedConfig2)
+	require.NoError(t, err)
+
+	err = tr1.Start()
+	require.NoError(t, err)
+
+	err = tr2.Start()
+	require.NoError(t, err)
+
+	tr1.SendConsensus([]raftpb.Message{{To: 2}})
+	tr1.SendConsensus([]raftpb.Message{{To: 2}})
+
+	tr2.SendConsensus([]raftpb.Message{{To: 1}})
+	tr2.SendConsensus([]raftpb.Message{{To: 1}})
+	tr2.SendConsensus([]raftpb.Message{{To: 1}})
+
+	require.Eventually(t, func() bool { return cl1.ReportUnreachableCallCount() == 2 }, 5*time.Second, 100*time.Millisecond)
+	require.Eventually(t, func() bool { return cl2.ReportUnreachableCallCount() == 3 }, 5*time.Second, 100*time.Millisecond)
+
+	require.Equal(t, 0, cl1.ProcessCallCount())
+	require.Equal(t, 0, cl2.ProcessCallCount())
+
+	require.Equal(t, 0, cl1.IsIDRemovedCallCount())
+	require.Equal(t, 0, cl2.IsIDRemovedCallCount())
+
+	tr1.Close()
+	tr2.Close()
+
+	t.Log("Analyzing logs:")
+	require.True(t, observedLogs.Len() > 0)
+	failedHandshake := 0
+	for _, entry := range observedLogs.All() {
+		fmt.Printf("%s | %s | %v \n", entry.Time, entry.Message, entry.ContextMap())
+
+		if strings.Contains(entry.Message, "peer deactivated") {
+			ctxMap := entry.ContextMap()
+			id, ok := ctxMap["peer-id"]
+			require.True(t, ok)
+			errS, ok := ctxMap["error"]
+			require.True(t, ok)
+
+			fmt.Printf("%s | %s | %v \n", entry.Time, entry.Message, entry.ContextMap())
+			switch id {
+			case "1":
+				fallthrough
+			case "2":
+				if strings.Contains(errS.(string), "x509: certificate signed by unknown authority") {
+					failedHandshake++
+				}
+			default:
+				t.Failed()
+			}
+		}
+	}
+	require.True(t, failedHandshake > 2)
+}
+
+// Scenario: missing certificate.
+func TestNewHTTPTransport_TLS_FilePathFailure(t *testing.T) {
+	lg, err := logger.New(&logger.Config{
+		Level:         "info",
+		OutputPath:    []string{"stdout"},
+		ErrOutputPath: []string{"stderr"},
+		Encoding:      "console",
+	})
+	require.NoError(t, err)
+
+	localConfigs, _ := newTestSetup(t, 1)
+	localConfigs[0].Replication.TLS.Enabled = true
+	localConfigs[0].Replication.TLS.ServerCertificatePath = "/bogus-path"
+	_, err = comm.NewHTTPTransport(&comm.Config{
+		LocalConf: localConfigs[0],
+		Logger:    lg,
+	})
+	require.EqualError(t, err, "failed to read local config Replication.TLS.ServerCertificatePath: open /bogus-path: no such file or directory")
+}
+
+func newTestSetup(t *testing.T, numServers int) ([]*config.LocalConfiguration, *types.ClusterConfig) {
+	var nodeIDs []string
+	for i := 0; i < numServers; i++ {
+		nodeIDs = append(nodeIDs, fmt.Sprintf("node%d", i+1))
+	}
+	cryptoDir := testutils.GenerateTestClientCrypto(t, nodeIDs, true)
+	auxDir, err := ioutil.TempDir("/tmp", "UnitTestAux")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.RemoveAll(auxDir)
+	})
+
 	configs := make([]*config.LocalConfiguration, 0)
 	for i := 0; i < numServers; i++ {
+		nodeID := fmt.Sprintf("node%d", i+1)
 		config := &config.LocalConfiguration{
 			Server: config.ServerConf{
 				Identity: config.IdentityConf{
-					ID: fmt.Sprintf("node%d", i+1),
+					ID: nodeID,
 				},
 			},
 			Replication: config.ReplicationConf{
+				AuxDir: path.Join(auxDir, nodeID),
 				Network: config.NetworkConf{
 					Address: "127.0.0.1",
 					Port:    uint32(33000 + i),
 				},
-				TLS: config.TLSConf{Enabled: false},
+				TLS: config.TLSConf{
+					Enabled:               false,
+					ClientAuthRequired:    false,
+					ServerCertificatePath: path.Join(cryptoDir, nodeID+".pem"),
+					ServerKeyPath:         path.Join(cryptoDir, nodeID+".key"),
+					ClientCertificatePath: path.Join(cryptoDir, nodeID+".pem"),
+					ClientKeyPath:         path.Join(cryptoDir, nodeID+".key"),
+					CaConfig: config.CAConfiguration{
+						RootCACertsPath:         []string{path.Join(cryptoDir, testutils.RootCAFileName+".pem")},
+						IntermediateCACertsPath: []string{path.Join(cryptoDir, testutils.IntermediateCAFileName+".pem")},
+					},
+				},
 			},
 			Bootstrap: config.BootstrapConf{},
 		}

--- a/internal/comm/log_adapter.go
+++ b/internal/comm/log_adapter.go
@@ -1,0 +1,23 @@
+// Copyright IBM Corp. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package comm
+
+import (
+	"github.com/hyperledger-labs/orion-server/pkg/logger"
+)
+
+type LogAdapter struct {
+	SugarLogger *logger.SugarLogger
+	Debug       bool
+}
+
+func (l *LogAdapter) Write(p []byte) (n int, err error) {
+	if l.Debug {
+		l.SugarLogger.Debug(string(p))
+	} else {
+		l.SugarLogger.Info(string(p))
+	}
+
+	return len(p), nil
+}

--- a/internal/replication/blockreplicator_test.go
+++ b/internal/replication/blockreplicator_test.go
@@ -92,7 +92,7 @@ func TestBlockReplicator_Restart(t *testing.T) {
 	env.conf.Transport.Close()
 
 	//recreate
-	env.conf.Transport = comm.NewHTTPTransport(&comm.Config{LocalConf: env.conf.LocalConf, Logger: env.conf.Logger})
+	env.conf.Transport, _ = comm.NewHTTPTransport(&comm.Config{LocalConf: env.conf.LocalConf, Logger: env.conf.Logger})
 	env.conf.BlockOneQueueBarrier = queue.NewOneQueueBarrier(env.conf.Logger)
 	env.blockReplicator, err = replication.NewBlockReplicator(env.conf)
 	require.NoError(t, err)
@@ -335,7 +335,7 @@ func TestBlockReplicator_Submit(t *testing.T) {
 		env.conf.Transport.Close()
 
 		//recreate
-		env.conf.Transport = comm.NewHTTPTransport(&comm.Config{LocalConf: env.conf.LocalConf, Logger: env.conf.Logger})
+		env.conf.Transport, _ = comm.NewHTTPTransport(&comm.Config{LocalConf: env.conf.LocalConf, Logger: env.conf.Logger})
 		env.conf.BlockOneQueueBarrier = queue.NewOneQueueBarrier(env.conf.Logger)
 		env.blockReplicator, err = replication.NewBlockReplicator(env.conf)
 		require.NoError(t, err)

--- a/internal/replication/env_test.go
+++ b/internal/replication/env_test.go
@@ -113,7 +113,7 @@ func (n *nodeEnv) Restart() error {
 	}
 
 	//recreate
-	n.conf.Transport = comm.NewHTTPTransport(
+	n.conf.Transport, _ = comm.NewHTTPTransport(
 		&comm.Config{
 			LedgerReader: n.conf.LedgerReader,
 			LocalConf:    n.conf.LocalConf,
@@ -280,7 +280,7 @@ func newNodeEnv(n uint32, testDir string, lg *logger.SugarLogger, clusterConfig 
 		return nil, err
 	}
 
-	peerTransport := comm.NewHTTPTransport(&comm.Config{
+	peerTransport, _ := comm.NewHTTPTransport(&comm.Config{
 		LedgerReader: ledger,
 		LocalConf:    localConf,
 		Logger:       lg,

--- a/pkg/certificateauthority/ca_chain_test.go
+++ b/pkg/certificateauthority/ca_chain_test.go
@@ -3,6 +3,8 @@
 package certificateauthority
 
 import (
+	"github.com/hyperledger-labs/orion-server/config"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -188,4 +190,23 @@ func TestCACertCollection_VerifyCollection(t *testing.T) {
 		require.NoError(t, err)
 		assertVerify(t, caCertCollection, false, true, false)
 	})
+}
+
+func TestLoadCAConfig(t *testing.T) {
+	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"user", "node"}, true)
+
+	rootCAFileName := path.Join(cryptoDir, testutils.RootCAFileName+".pem")
+	interCAFileName := path.Join(cryptoDir, testutils.IntermediateCAFileName+".pem")
+
+	caConfiguration := &config.CAConfiguration{
+		RootCACertsPath:         []string{rootCAFileName},
+		IntermediateCACertsPath: []string{interCAFileName},
+	}
+
+	caConfig, err := LoadCAConfig(caConfiguration)
+	require.NoError(t, err)
+	require.NotNil(t, caConfig)
+	caColl, err := NewCACertCollection(caConfig.GetRoots(), caConfig.GetIntermediates())
+	require.NoError(t, err)
+	require.NotNil(t, caColl)
 }


### PR DESCRIPTION
Support TLS for peer server to server communication.
The server accepts only TLS connections, the client dials TLS.
Client authentication is not yet supported (future commit).
Client authorization is not yet supported (future commit).

Some utilities where added to load the CA certificates from disk, verify them,
and pack then all into a single bundle, as the rafthttp transport expects.

Signed-off-by: Yoav Tock <tock@il.ibm.com>