### PR TITLE
encoder for value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ goimports:
 binary:
 	go build -o $(BIN)/bdb cmd/bdb/main.go
 	go build -o $(BIN)/signer cmd/signer/signer.go
+	go build -o $(BIN)/encoder cmd/base64_encoder/encoder.go
 
 .PHONY: test
 test-script: 

--- a/cmd/base64_encoder/encoder.go
+++ b/cmd/base64_encoder/encoder.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"encoding/base64"
+	"flag"
+	"fmt"
+)
+
+var help = "The data field accepts a JSON or a string value. THE data flag must be set. Two example commands are shown below: \n\n" +
+	"  encoder -data='{\"userID\":\"admin\"}' \n" +
+	"  encoder -data='value' \n"
+
+func main() {
+	data := flag.String("data", "", "json or string data to be encoded. Surround the JSON data with single quotes. An example json data is '{\"userID\":\"admin\"}'")
+
+	flag.CommandLine.Output()
+	flag.Parse()
+
+	if *data == "" {
+		fmt.Println(help)
+		flag.PrintDefaults()
+		return
+	}
+
+	fmt.Println(base64.StdEncoding.EncodeToString([]byte(*data)))
+}

--- a/cmd/base64_encoder/encoder_test.go
+++ b/cmd/base64_encoder/encoder_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/base64"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncoder(t *testing.T) {
+	t.Run("incorrect args", func(t *testing.T) {
+		for _, arg := range []string{
+			"",
+			"abc",
+		} {
+			out, err := exec.Command("go", "run", "encoder.go", arg).CombinedOutput()
+			require.NoError(t, err)
+
+			expectedOut := help + "\n  -data string\n    \tjson or string data to be encoded. " +
+				"Surround the JSON data with single quotes. " +
+				"An example json data is '{\"userID\":\"admin\"}'\n"
+			require.Equal(t, expectedOut, string(out))
+		}
+	})
+
+	t.Run("correct args", func(t *testing.T) {
+		for _, data := range []string{
+			"'{\"user_id\":\"admin\"}'",
+			"name",
+		} {
+			args := []string{
+				"run",
+				"encoder.go",
+				"-data=" + data,
+			}
+
+			out, err := exec.Command("go", args...).Output()
+			require.NoError(t, err)
+
+			out, err = base64.StdEncoding.DecodeString(string(out))
+			require.NoError(t, err)
+			require.Equal(t, []byte(data), out)
+		}
+	})
+}


### PR DESCRIPTION
This commit adds an utility that can encode the given data to
base64 string. Note that this utility accepts either a JSON or
string value only.

Signed-off-by: senthil <cendhu@gmail.com>