### PR TITLE
decoder decodes data response envelope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ binary:
 	go build -o $(BIN)/bdb cmd/bdb/main.go
 	go build -o $(BIN)/signer cmd/signer/signer.go
 	go build -o $(BIN)/encoder cmd/base64_encoder/encoder.go
+	go build -o $(BIN)/decoder cmd/base64_decoder/decoder.go
 
 .PHONY: test
 test-script: 

--- a/cmd/base64_decoder/decoder.go
+++ b/cmd/base64_decoder/decoder.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+
+	"github.com/hyperledger-labs/orion-server/pkg/types"
+)
+
+var help = "The decoder decodes the base64 encoded value field in the " +
+	"GetDataResponseEnvelope. Pass the json output of " +
+	"GetDataResponseEnvelope to the `-getresponse` flag"
+
+type GetDataResponseEnvelope struct {
+	Response  *GetDataResponse `json:"response,omitempty"`
+	Signature []byte           `json:"signature,omitempty"`
+}
+
+type GetDataResponse struct {
+	Header   *types.ResponseHeader `json:"header,omitempty"`
+	Value    string                `json:"value,omitempty"`
+	Metadata *types.Metadata       `json:"metadata,omitempty"`
+}
+
+func main() {
+	getresponse := flag.String(
+		"getresponse",
+		"",
+		"json output of GetDataResponseEnvelope. The value field in the json output will be decoded. Surround the JSON data with single quotes.",
+	)
+
+	flag.CommandLine.Output()
+	flag.Parse()
+
+	if *getresponse == "" {
+		fmt.Println(help)
+		flag.PrintDefaults()
+		return
+	}
+
+	r := &types.GetDataResponseEnvelope{}
+	if err := json.Unmarshal([]byte(*getresponse), r); err != nil {
+		fmt.Printf("the json data provided for -getresponse flag does not get marshalled to `GetDataResponseEnvelope`, err:%s\n", err.Error())
+		return
+	}
+
+	decodedResponse := &GetDataResponseEnvelope{
+		Response: &GetDataResponse{
+			Header:   r.GetResponse().GetHeader(),
+			Value:    string(r.GetResponse().GetValue()),
+			Metadata: r.GetResponse().GetMetadata(),
+		},
+		Signature: r.GetSignature(),
+	}
+	jsonDecodedResponse, err := json.Marshal(decodedResponse)
+	if err != nil {
+		fmt.Printf("error marshalling decoded response, err:%s\n", err.Error())
+		return
+	}
+	fmt.Printf(string(jsonDecodedResponse))
+}

--- a/cmd/base64_decoder/decoder_test.go
+++ b/cmd/base64_decoder/decoder_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncoder(t *testing.T) {
+	t.Run("incorrect args", func(t *testing.T) {
+		for _, arg := range []string{
+			"",
+			"abc",
+		} {
+			out, err := exec.Command("go", "run", "decoder.go", arg).CombinedOutput()
+			require.NoError(t, err)
+
+			expectedOut := help + "\n  -getresponse string\n    \tjson output of " +
+				"GetDataResponseEnvelope. The value field in the json output will be decoded. " +
+				"Surround the JSON data with single quotes.\n"
+			require.Equal(t, expectedOut, string(out))
+		}
+	})
+
+	t.Run("correct args", func(t *testing.T) {
+		data := `{"response":{"header":{"node_id":"bdb-node-1"},"value":"eyJuYW1lIjoiYWJjIiwiYWdlIjozMSwiZ3JhZHVhdGVkIjp0cnVlfQ==","metadata":{"version":{"block_num":4},"access_control":{"read_users":{"alice":true,"bob":true},"read_write_users":{"alice":true}}}},"signature":"MEYCIQCRpq5MCakj+GP0xLe8GbVH8rA0pQehW4EOfLyVWLdXUAIhANv5PtZG9Sw8mN6c0jIwuqL03kM+GZT0m4H2qtHRnIIS"}`
+
+		args := []string{
+			"run",
+			"decoder.go",
+			"-getresponse=" + data,
+		}
+
+		out, err := exec.Command("go", args...).Output()
+		require.NoError(t, err)
+
+		expectedOut := `{"response":{"header":{"node_id":"bdb-node-1"},"value":"{\"name\":\"abc\",\"age\":31,\"graduated\":true}","metadata":{"version":{"block_num":4},"access_control":{"read_users":{"alice":true,"bob":true},"read_write_users":{"alice":true}}}},"signature":"MEYCIQCRpq5MCakj+GP0xLe8GbVH8rA0pQehW4EOfLyVWLdXUAIhANv5PtZG9Sw8mN6c0jIwuqL03kM+GZT0m4H2qtHRnIIS"}`
+		require.Equal(t, expectedOut, string(out))
+	})
+}


### PR DESCRIPTION
This commits add a decoder utility that would decode
a given json data response envelope.

It will get updated to decode the bas64 encoded value
in the subsequent PR.

Signed-off-by: senthil <cendhu@gmail.com>