### PR TITLE
ConsensusConfig reconfig rules

### DIFF
--- a/internal/replication/utils.go
+++ b/internal/replication/utils.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"hash/crc64"
 
-	"github.com/hyperledger-labs/orion-server/pkg/types"
 	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/orion-server/pkg/logger"
+	"github.com/hyperledger-labs/orion-server/pkg/types"
+	"github.com/pkg/errors"
 	"go.etcd.io/etcd/raft"
 	"go.etcd.io/etcd/raft/raftpb"
 )
@@ -28,7 +30,86 @@ func raftEntryString(e raftpb.Entry) string {
 		e.Term, e.Index, e.Type, len(e.Data), h.Sum64())
 }
 
+// VerifyConsensusReConfig checks the configuration changes in types.ConsensusConfig.
+//
+// This method checks that the changes between one ConsensusConfig to the next are safe, because some mutations might
+// cause a permanent loss of quorum in the cluster, something that is very difficult to recover from.
+// - Members can be added or removed (membership change) one member at a time
+// - Members' endpoints cannot be changed together with a membership change
+// - An existing member cannot change its Raft ID (it must be removed from the cluster and added again as a new member)
+// - The Raft ID of a new member must be unique - therefore it must be larger than MaxRaftId
+//
+// We assume that both the current and updated ClusterConfig are internally consistent, specifically, that the Nodes
+// and the ConsensusConfig.Members arrays match by NodeId in each.
+func VerifyConsensusReConfig(currentConfig, updatedConfig *types.ConsensusConfig, lg *logger.SugarLogger) error {
+	addedPeers, removedPeers, changedPeers, err := detectPeerConfigChanges(currentConfig, updatedConfig)
+	if err != nil {
+		return err
+	}
+
+	if len(addedPeers)+len(removedPeers) > 1 {
+		return errors.Errorf("cannot make more than one membership change at a time: %d added, %d removed", len(addedPeers), len(removedPeers))
+	}
+
+	if (len(addedPeers)+len(removedPeers) == 1) && len(changedPeers) > 1 {
+		return errors.Errorf("cannot update peer endpoints while making membership changes: %d added, %d removed, %d updated", len(addedPeers), len(removedPeers), len(changedPeers))
+	}
+
+	if len(addedPeers)+len(removedPeers) == 1 {
+		// TODO support dynamic membership changes, see:
+		return errors.New("dynamic membership changes to the cluster are not supported yet")
+	}
+
+	if !proto.Equal(currentConfig.RaftConfig, updatedConfig.RaftConfig) {
+		lg.Warning("ConsensusConfig RaftConfig changed, the new RaftConfig will be applied after server restart!")
+	}
+
+	return nil
+}
+
+func detectPeerConfigChanges(currentConfig, updatedConfig *types.ConsensusConfig) (addedPeers, removedPeers, changedPeers []*types.PeerConfig, err error) {
+	currPeers := make(map[string]*types.PeerConfig)
+	for _, m := range currentConfig.Members {
+		currPeers[m.NodeId] = m
+	}
+
+	updtPeers := make(map[string]*types.PeerConfig)
+	for _, updtMember := range updatedConfig.Members {
+		updtPeers[updtMember.NodeId] = updtMember
+		if currMember, ok := currPeers[updtMember.NodeId]; ok {
+			// existing peer
+			if !proto.Equal(updtMember, currMember) {
+				if updtMember.RaftId != currMember.RaftId {
+					return nil, nil, nil,
+						errors.Errorf("cannot change the RaftId of an existing peer: NodeId=%s, current=%d, updated=%d",
+							currMember.NodeId, currMember.RaftId, updtMember.RaftId)
+				}
+				changedPeers = append(changedPeers, updtMember) //endpoint changed
+			}
+		} else {
+			// added peer
+			if updtMember.RaftId <= currentConfig.RaftConfig.MaxRaftId {
+				return nil, nil, nil,
+					errors.Errorf("the RaftId of a new peer must be unique,  > MaxRaftId [%d]; but: NodeId=%s, RaftID=%d",
+						currentConfig.RaftConfig.MaxRaftId, updtMember.NodeId, updtMember.RaftId)
+			}
+			addedPeers = append(addedPeers, updtMember)
+		}
+	}
+
+	for _, currMember := range currPeers {
+		if _, ok := updtPeers[currMember.NodeId]; !ok {
+			// removed peer
+			removedPeers = append(removedPeers, currMember)
+		}
+	}
+
+	return
+}
+
 // ClassifyClusterReConfig detects the kind of changes that happened in the ClusterConfig.
+// We assume that both the current and updated config are internally consistent (valid), but not necessarily with
+// respect to each other.
 func ClassifyClusterReConfig(currentConfig, updatedConfig *types.ClusterConfig) (nodes bool, consensus bool, ca bool, admins bool) {
 	nodes = changedNodes(currentConfig.GetNodes(), updatedConfig.GetNodes())
 

--- a/internal/replication/utils_test.go
+++ b/internal/replication/utils_test.go
@@ -1,0 +1,211 @@
+// Copyright IBM Corp. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package replication
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/orion-server/pkg/logger"
+	"github.com/hyperledger-labs/orion-server/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyClusterReConfig(t *testing.T) {
+	clusterConfig := testClusterConfig()
+
+	t.Run("nodes changed", func(t *testing.T) {
+		updatedConfig := proto.Clone(clusterConfig).(*types.ClusterConfig)
+		updatedConfig.Nodes[0].Port++
+
+		nodes, consensus, ca, admins := ClassifyClusterReConfig(clusterConfig, updatedConfig)
+		require.True(t, nodes)
+		require.False(t, consensus)
+		require.False(t, ca)
+		require.False(t, admins)
+	})
+
+	t.Run("consensus changed", func(t *testing.T) {
+		updatedConfig := proto.Clone(clusterConfig).(*types.ClusterConfig)
+		updatedConfig.ConsensusConfig.RaftConfig.SnapshotIntervalSize++
+
+		nodes, consensus, ca, admins := ClassifyClusterReConfig(clusterConfig, updatedConfig)
+		require.False(t, nodes)
+		require.True(t, consensus)
+		require.False(t, ca)
+		require.False(t, admins)
+	})
+
+	t.Run("ca changed", func(t *testing.T) {
+		updatedConfig := proto.Clone(clusterConfig).(*types.ClusterConfig)
+		updatedConfig.CertAuthConfig.Roots = append(updatedConfig.CertAuthConfig.Roots, []byte("root-certificate-2"))
+
+		nodes, consensus, ca, admins := ClassifyClusterReConfig(clusterConfig, updatedConfig)
+		require.False(t, nodes)
+		require.False(t, consensus)
+		require.True(t, ca)
+		require.False(t, admins)
+	})
+
+	t.Run("admins changed", func(t *testing.T) {
+		updatedConfig := proto.Clone(clusterConfig).(*types.ClusterConfig)
+		updatedConfig.Admins = append(updatedConfig.Admins, &types.Admin{
+			Id:          "admin2",
+			Certificate: []byte("admin2-certificate"),
+		})
+
+		nodes, consensus, ca, admins := ClassifyClusterReConfig(clusterConfig, updatedConfig)
+		require.False(t, nodes)
+		require.False(t, consensus)
+		require.False(t, ca)
+		require.True(t, admins)
+	})
+}
+
+func TestVerifyConsensusReConfig(t *testing.T) {
+	c := &logger.Config{
+		Level:         "debug",
+		OutputPath:    []string{"stdout"},
+		ErrOutputPath: []string{"stderr"},
+		Encoding:      "console",
+	}
+	lg, err = logger.New(c)
+	require.NoError(t, err)
+
+	clusterConfig := testClusterConfig()
+
+	t.Run("valid (todo): add a peer", func(t *testing.T) {
+		updateConfig := proto.Clone(clusterConfig.ConsensusConfig).(*types.ConsensusConfig)
+		updateConfig.Members = append(updateConfig.Members, &types.PeerConfig{
+			NodeId:   "node4",
+			RaftId:   6,
+			PeerHost: "127.0.0.1",
+			PeerPort: 7094,
+		})
+		err := VerifyConsensusReConfig(clusterConfig.ConsensusConfig, updateConfig, lg)
+		require.EqualError(t, err, "dynamic membership changes to the cluster are not supported yet")
+		// TODO require.NoError(t, err)
+	})
+
+	t.Run("valid (todo): remove a peer", func(t *testing.T) {
+		updateConfig := proto.Clone(clusterConfig.ConsensusConfig).(*types.ConsensusConfig)
+		updateConfig.Members = updateConfig.Members[0:2]
+		err := VerifyConsensusReConfig(clusterConfig.ConsensusConfig, updateConfig, lg)
+		require.EqualError(t, err, "dynamic membership changes to the cluster are not supported yet")
+		// TODO require.NoError(t, err)
+	})
+
+	t.Run("valid: change endpoints", func(t *testing.T) {
+		updateConfig := proto.Clone(clusterConfig.ConsensusConfig).(*types.ConsensusConfig)
+		for i := 0; i < len(updateConfig.Members); i++ {
+			updateConfig.Members[i].PeerPort = updateConfig.Members[i].PeerPort + 1000
+			err := VerifyConsensusReConfig(clusterConfig.ConsensusConfig, updateConfig, lg)
+			require.NoError(t, err)
+		}
+	})
+
+	t.Run("valid: change raft config", func(t *testing.T) {
+		updateConfig := proto.Clone(clusterConfig.ConsensusConfig).(*types.ConsensusConfig)
+		updateConfig.RaftConfig.SnapshotIntervalSize++
+		err := VerifyConsensusReConfig(clusterConfig.ConsensusConfig, updateConfig, lg)
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid: too many adds", func(t *testing.T) {
+		updateConfig := proto.Clone(clusterConfig.ConsensusConfig).(*types.ConsensusConfig)
+		updateConfig.Members = append(updateConfig.Members, &types.PeerConfig{
+			NodeId:   "node4",
+			RaftId:   6,
+			PeerHost: "127.0.0.1",
+			PeerPort: 7094,
+		})
+		updateConfig.Members = append(updateConfig.Members, &types.PeerConfig{
+			NodeId:   "node5",
+			RaftId:   7,
+			PeerHost: "127.0.0.1",
+			PeerPort: 7095,
+		})
+
+		err := VerifyConsensusReConfig(clusterConfig.ConsensusConfig, updateConfig, lg)
+		require.EqualError(t, err, "cannot make more than one membership change at a time: 2 added, 0 removed")
+	})
+
+	t.Run("invalid: too many removals", func(t *testing.T) {
+		updateConfig := proto.Clone(clusterConfig.ConsensusConfig).(*types.ConsensusConfig)
+		updateConfig.Members = updateConfig.Members[0:1]
+		err := VerifyConsensusReConfig(clusterConfig.ConsensusConfig, updateConfig, lg)
+		require.EqualError(t, err, "cannot make more than one membership change at a time: 0 added, 2 removed")
+	})
+
+	t.Run("invalid: add and remove", func(t *testing.T) {
+		updateConfig := proto.Clone(clusterConfig.ConsensusConfig).(*types.ConsensusConfig)
+		updateConfig.Members[2] = &types.PeerConfig{
+			NodeId:   "node4",
+			RaftId:   6,
+			PeerHost: "127.0.0.1",
+			PeerPort: 7094,
+		}
+		err := VerifyConsensusReConfig(clusterConfig.ConsensusConfig, updateConfig, lg)
+		require.EqualError(t, err, "cannot make more than one membership change at a time: 1 added, 1 removed")
+	})
+
+	t.Run("invalid: add a peer with non-unique RaftID", func(t *testing.T) {
+		updateConfig := proto.Clone(clusterConfig.ConsensusConfig).(*types.ConsensusConfig)
+		updateConfig.Members = append(updateConfig.Members, &types.PeerConfig{
+			NodeId:   "node4",
+			RaftId:   4,
+			PeerHost: "127.0.0.1",
+			PeerPort: 7094,
+		})
+		err := VerifyConsensusReConfig(clusterConfig.ConsensusConfig, updateConfig, lg)
+		require.EqualError(t, err, "the RaftId of a new peer must be unique,  > MaxRaftId [5]; but: NodeId=node4, RaftID=4")
+	})
+}
+
+func testClusterConfig() *types.ClusterConfig {
+	clusterConfig := &types.ClusterConfig{
+		Admins: []*types.Admin{
+			{
+				Id:          "admin",
+				Certificate: []byte("admin-certificate"),
+			},
+		},
+		CertAuthConfig: &types.CAConfig{
+			Roots:         [][]byte{[]byte("root-certificate")},
+			Intermediates: [][]byte{[]byte("inter-certificate")},
+		},
+		ConsensusConfig: &types.ConsensusConfig{
+			Algorithm: "raft",
+			RaftConfig: &types.RaftConfig{
+				TickInterval:         "20ms",
+				ElectionTicks:        100,
+				HeartbeatTicks:       10,
+				MaxInflightBlocks:    50,
+				SnapshotIntervalSize: 1000000,
+				MaxRaftId:            5,
+			},
+		},
+	}
+
+	for n := uint32(1); n <= uint32(3); n++ {
+		nodeID := fmt.Sprintf("node%d", n)
+		nodeConfig := &types.NodeConfig{
+			Id:          nodeID,
+			Address:     "127.0.0.1",
+			Port:        6090 + n,
+			Certificate: []byte("bogus-cert"),
+		}
+		peerConfig := &types.PeerConfig{
+			NodeId:   nodeID,
+			RaftId:   uint64(n),
+			PeerHost: "127.0.0.1",
+			PeerPort: 7090 + n,
+		}
+		clusterConfig.Nodes = append(clusterConfig.Nodes, nodeConfig)
+		clusterConfig.ConsensusConfig.Members = append(clusterConfig.ConsensusConfig.Members, peerConfig)
+	}
+
+	return clusterConfig
+}


### PR DESCRIPTION
Define the rules for updating the ConsensusConfig, in particular, the Memebrs.

The core contribution is the VerifyConsensusReConfig method, that checks the configuration changes in types.ConsensusConfig.

This method checks that the changes between one ConsensusConfig to the next are safe, because some mutations might
cause a permanent loss of quorum in the cluster, something that is very difficult to recover from.
 - Members can be added or removed (membership change) one member at a time
 - Members' endpoints cannot be changed together with a membership change
 - An existing member cannot change its Raft ID (it must be removed from the cluster and added again as a new member)
 - The Raft ID of a new member must be unique - therefore it must be larger than MaxRaftId

We assume that both the current and updated ClusterConfig are internally consistent, specifically, that the Nodes
and the ConsensusConfig.Members arrays match by NodeId in each.

Signed-off-by: Yoav Tock <tock@il.ibm.com>