### PR TITLE
Re-config cluster membership: peer removal

### DIFF
--- a/internal/httputils/blocks.go
+++ b/internal/httputils/blocks.go
@@ -70,3 +70,12 @@ func BlockPayloadToTxIDs(blockPayload interface{}) ([]string, error) {
 
 	return txIDs, nil
 }
+
+func IsConfigBlock(block *types.Block) bool {
+	switch block.GetPayload().(type) {
+	case *types.Block_ConfigTxEnvelope:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/httputils/blocks_test.go
+++ b/internal/httputils/blocks_test.go
@@ -207,3 +207,51 @@ func TestBlockPayloadToTxIDs_Errors(t *testing.T) {
 		require.Nil(t, txIDs)
 	})
 }
+
+func TestIsConfigBlock(t *testing.T) {
+	type testCase struct {
+		name     string
+		block    *types.Block
+		expected bool
+	}
+
+	testCases := []*testCase{
+		{
+			name:     "nil block",
+			block:    nil,
+			expected: false,
+		},
+		{
+			name:     "empty block",
+			block:    &types.Block{},
+			expected: false,
+		},
+		{
+			name:     "data block",
+			block:    &types.Block{Payload: &types.Block_DataTxEnvelopes{}},
+			expected: false,
+		},
+		{
+			name:     "user admin block",
+			block:    &types.Block{Payload: &types.Block_UserAdministrationTxEnvelope{}},
+			expected: false,
+		},
+		{
+			name:     "db admin block",
+			block:    &types.Block{Payload: &types.Block_DbAdministrationTxEnvelope{}},
+			expected: false,
+		},
+		{
+			name:     "config block",
+			block:    &types.Block{Payload: &types.Block_ConfigTxEnvelope{}},
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			isConfig := httputils.IsConfigBlock(tc.block)
+			require.Equal(t, tc.expected, isConfig)
+		})
+	}
+}

--- a/internal/replication/utils.go
+++ b/internal/replication/utils.go
@@ -36,6 +36,7 @@ func raftEntryString(e raftpb.Entry) string {
 // cause a permanent loss of quorum in the cluster, something that is very difficult to recover from.
 // - Members can be added or removed (membership change) one member at a time
 // - Members' endpoints cannot be changed together with a membership change
+// - Members' endpoints can be updated one at a time
 // - An existing member cannot change its Raft ID (it must be removed from the cluster and added again as a new member)
 // - The Raft ID of a new member must be unique - therefore it must be larger than MaxRaftId
 //
@@ -55,7 +56,7 @@ func VerifyConsensusReConfig(currentConfig, updatedConfig *types.ConsensusConfig
 		return errors.Errorf("cannot update peer endpoints while making membership changes: %d added, %d removed, %d updated", len(addedPeers), len(removedPeers), len(changedPeers))
 	}
 
-	if len(addedPeers)+len(removedPeers) == 1 {
+	if len(addedPeers) == 1 {
 		// TODO support dynamic membership changes, see:
 		return errors.New("dynamic membership changes to the cluster are not supported yet")
 	}

--- a/internal/replication/utils_test.go
+++ b/internal/replication/utils_test.go
@@ -89,12 +89,11 @@ func TestVerifyConsensusReConfig(t *testing.T) {
 		// TODO require.NoError(t, err)
 	})
 
-	t.Run("valid (todo): remove a peer", func(t *testing.T) {
+	t.Run("valid: remove a peer", func(t *testing.T) {
 		updateConfig := proto.Clone(clusterConfig.ConsensusConfig).(*types.ConsensusConfig)
 		updateConfig.Members = updateConfig.Members[0:2]
 		err := VerifyConsensusReConfig(clusterConfig.ConsensusConfig, updateConfig, lg)
-		require.EqualError(t, err, "dynamic membership changes to the cluster are not supported yet")
-		// TODO require.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("valid: change endpoints", func(t *testing.T) {


### PR DESCRIPTION
Handle a config TX that carries a membership change, i.e. adding or removing a member peer.

If a config transaction carries changes to the cluster membership, i.e. add or remove a node, it is proposed
using Raft’s ProposeConfChange(), with the config-block as Context field of the proposal.
This allows consensus on the new Raft membership, while consenting on the new config-block at the same time.
If the config tx does not carry changes to the cluster membership it is proposed using the normal Propose().

Implement peer removal and addition, but test only removal.
- When a node is removed, it is recommended to shutdown the removed node prior to proposing the removal config-tx.
- If the removed node is alive, it detects its own removal after it commits and then shuts down the replication component.
- The removed server may continue to serve queries until it is shutdown.
- The removed server always reports the Leader-RaftID=0, so it cannot be used for transactions.

Adding a peer is still not supported (future commit).