### PR TITLE
Re-config comm transport endpoints

### DIFF
--- a/internal/bcdb/transaction_processor.go
+++ b/internal/bcdb/transaction_processor.go
@@ -136,7 +136,7 @@ func newTransactionProcessor(conf *txProcessorConfig) (*transactionProcessor, er
 		return nil, err
 	}
 	conf.logger.Debugf("cluster config: %+v", clusterConfig)
-	if err = p.peerTransport.UpdateClusterConfig(clusterConfig); err != nil {
+	if err = p.peerTransport.SetClusterConfig(clusterConfig); err != nil {
 		return nil, err
 	}
 

--- a/internal/comm/httptransport_catchup_test.go
+++ b/internal/comm/httptransport_catchup_test.go
@@ -45,7 +45,7 @@ func TestHTTPTransport_CatchupService(t *testing.T) {
 	require.NotNil(t, tr1)
 	err = tr1.SetConsensusListener(cl1)
 	require.NoError(t, err)
-	err = tr1.UpdateClusterConfig(sharedConfig)
+	err = tr1.SetClusterConfig(sharedConfig)
 	require.NoError(t, err)
 
 	err = tr1.Start()

--- a/internal/replication/blockreplicator_test.go
+++ b/internal/replication/blockreplicator_test.go
@@ -98,7 +98,7 @@ func TestBlockReplicator_Restart(t *testing.T) {
 	require.NoError(t, err)
 	err = env.conf.Transport.SetConsensusListener(env.blockReplicator)
 	require.NoError(t, err)
-	err = env.conf.Transport.UpdateClusterConfig(env.conf.ClusterConfig)
+	err = env.conf.Transport.SetClusterConfig(env.conf.ClusterConfig)
 	require.NoError(t, err)
 
 	//restart
@@ -341,7 +341,7 @@ func TestBlockReplicator_Submit(t *testing.T) {
 		require.NoError(t, err)
 		err = env.conf.Transport.SetConsensusListener(env.blockReplicator)
 		require.NoError(t, err)
-		err = env.conf.Transport.UpdateClusterConfig(env.conf.ClusterConfig)
+		err = env.conf.Transport.SetClusterConfig(env.conf.ClusterConfig)
 		require.NoError(t, err)
 
 		//restart

--- a/internal/replication/env_test.go
+++ b/internal/replication/env_test.go
@@ -133,7 +133,7 @@ func (n *nodeEnv) Restart() error {
 		return err
 	}
 
-	err = n.conf.Transport.UpdateClusterConfig(n.conf.ClusterConfig)
+	err = n.conf.Transport.SetClusterConfig(n.conf.ClusterConfig)
 	if err != nil {
 		return err
 	}
@@ -306,7 +306,7 @@ func newNodeEnv(n uint32, testDir string, lg *logger.SugarLogger, clusterConfig 
 		return nil, err
 	}
 
-	err = conf.Transport.UpdateClusterConfig(conf.ClusterConfig)
+	err = conf.Transport.SetClusterConfig(conf.ClusterConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Allow the HTTPTransport to update its member peers - add peer / remove peer / change peer endpoint.
This includes both the raft http transport and the catchup client.

Note: a config TX that adds or removes peers is not yet supported (future commit).