### PR TITLE
Re-config cluster membership: peer addition

### DIFF
--- a/internal/blockprocessor/config_tx_validator_test.go
+++ b/internal/blockprocessor/config_tx_validator_test.go
@@ -371,7 +371,7 @@ func TestValidateConfigTx(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid: unsupported yet: consensus peer membership change",
+			name: "valid: consensus peer membership change",
 			txEnv: testutils.SignedConfigTxEnvelope(t, adminSigner, &types.ConfigTx{
 				UserId: "adminUser",
 				ReadOldConfigVersion: &types.Version{
@@ -428,8 +428,7 @@ func TestValidateConfigTx(t *testing.T) {
 				},
 			}),
 			expectedResult: &types.ValidationInfo{
-				Flag: types.Flag_INVALID_INCORRECT_ENTRIES,
-				ReasonIfInvalid: "error in ConsensusConfig: dynamic membership changes to the cluster are not supported yet",
+				Flag: types.Flag_VALID,
 			},
 		},
 		{

--- a/internal/replication/blockreplicator.go
+++ b/internal/replication/blockreplicator.go
@@ -186,13 +186,13 @@ func NewBlockReplicator(conf *Config) (*BlockReplicator, error) {
 
 	lg.Debugf("haveWAL: %v, Storage: %v, Raft config: %+v", haveWAL, storage, raftConfig)
 
-	joinExistingCluster := false // TODO support node join to an existing cluster
+	joinExistingCluster := false // TODO support node join to an existing cluster: https://github.com/hyperledger-labs/orion-server/issues/260
 
 	if haveWAL {
 		br.raftNode = raft.RestartNode(raftConfig)
 	} else {
 		if joinExistingCluster {
-			// TODO support node join to an existing cluster
+			// TODO support node join to an existing cluster: https://github.com/hyperledger-labs/orion-server/issues/260
 			br.lg.Panicf("not supported yet: joinExistingCluster")
 		} else {
 			startPeers := raftPeers(br.clusterConfig)

--- a/internal/replication/utils.go
+++ b/internal/replication/utils.go
@@ -56,11 +56,6 @@ func VerifyConsensusReConfig(currentConfig, updatedConfig *types.ConsensusConfig
 		return errors.Errorf("cannot update peer endpoints while making membership changes: %d added, %d removed, %d updated", len(addedPeers), len(removedPeers), len(changedPeers))
 	}
 
-	if len(addedPeers) == 1 {
-		// TODO support dynamic membership changes, see:
-		return errors.New("dynamic membership changes to the cluster are not supported yet")
-	}
-
 	if !proto.Equal(currentConfig.RaftConfig, updatedConfig.RaftConfig) {
 		lg.Warning("ConsensusConfig RaftConfig changed, the new RaftConfig will be applied after server restart!")
 	}

--- a/internal/replication/utils_test.go
+++ b/internal/replication/utils_test.go
@@ -85,8 +85,7 @@ func TestVerifyConsensusReConfig(t *testing.T) {
 			PeerPort: 7094,
 		})
 		err := VerifyConsensusReConfig(clusterConfig.ConsensusConfig, updateConfig, lg)
-		require.EqualError(t, err, "dynamic membership changes to the cluster are not supported yet")
-		// TODO require.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("valid: remove a peer", func(t *testing.T) {


### PR DESCRIPTION
Allow a config-tx to carry a membership change that adds a peer.
Test that the peer was added to the existing cluster.
Note that bootstrapping the peer is not yet supported (future commit).