### PR TITLE
Cluster bootstrap join in replication

### DIFF
--- a/internal/bcdb/transaction_processor.go
+++ b/internal/bcdb/transaction_processor.go
@@ -185,18 +185,20 @@ func newTransactionProcessor(conf *txProcessorConfig) (*transactionProcessor, er
 		return nil, err
 	}
 
-	p.blockReplicator, err = replication.NewBlockReplicator(
-		&replication.Config{
-			LocalConf:            localConfig,
-			ClusterConfig:        clusterConfig,
-			JoinBlock:            conf.config.JoinBlock,
-			LedgerReader:         conf.blockStore,
-			Transport:            p.peerTransport,
-			BlockOneQueueBarrier: p.blockOneQueueBarrier,
-			PendingTxs:           p.pendingTxs,
-			Logger:               conf.logger,
-		},
-	)
+	repConfig := &replication.Config{
+		LocalConf:            localConfig,
+		ClusterConfig:        clusterConfig,
+		LedgerReader:         conf.blockStore,
+		Transport:            p.peerTransport,
+		BlockOneQueueBarrier: p.blockOneQueueBarrier,
+		PendingTxs:           p.pendingTxs,
+		Logger:               conf.logger,
+	}
+	if joinStart {
+		repConfig.JoinBlock = conf.config.JoinBlock
+	}
+
+	p.blockReplicator, err = replication.NewBlockReplicator(repConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/replication/blockreplicator_reconfig_test.go
+++ b/internal/replication/blockreplicator_reconfig_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/orion-server/internal/replication"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -62,15 +63,7 @@ func TestBlockReplicator_ReConfig_Endpoint(t *testing.T) {
 	}
 	require.Eventually(t, isLeaderCond, 30*time.Second, 100*time.Millisecond)
 
-	block := &types.Block{
-		Header: &types.BlockHeader{
-			BaseHeader: &types.BlockHeaderBase{
-				Number:                1,
-				LastCommittedBlockNum: 1,
-			},
-		},
-		Payload: &types.Block_DataTxEnvelopes{},
-	}
+	block, _ := testDataBlock(0)
 
 	leaderIdx := env.AgreedLeaderIndex()
 	expectedNotLeaderErr := fmt.Sprintf("not a leader, leader is RaftID: %d, with HostPort: 127.0.0.1:2200%d", leaderIdx+1, leaderIdx+1)
@@ -211,15 +204,7 @@ func testReConfigPeerRemoveBefore(t *testing.T, env *clusterEnv, numBlocks uint6
 	}
 	require.Eventually(t, isLeaderCond, 30*time.Second, 100*time.Millisecond)
 
-	block := &types.Block{
-		Header: &types.BlockHeader{
-			BaseHeader: &types.BlockHeaderBase{
-				Number:                1,
-				LastCommittedBlockNum: 1,
-			},
-		},
-		Payload: &types.Block_DataTxEnvelopes{},
-	}
+	block, _ := testDataBlock(0)
 
 	leaderIdx := env.AgreedLeaderIndex()
 	for i := uint64(0); i < numBlocks; i++ {
@@ -277,8 +262,14 @@ func testReConfigPeerRemoveAfter(t *testing.T, env *clusterEnv, removePeerIdx in
 	}
 }
 
+// Scenario: add a peer to the cluster
+// - start 3 nodes, wait for leader, submit a few blocks and verify reception by all
+// - submit a config tx to adds a 4th peer, wait for all 3 to get it
+// - start the 4th peer with a join block derived from said config-tx
+// - ensure the new node generates a snapshot from the join block
+// - ensure the new node can restart from that snapshot
+// - submit a few blocks and check that all nodes got them, including the 4th node
 func TestBlockReplicator_ReConfig_AddPeer(t *testing.T) {
-
 	var countMutex sync.Mutex
 	var addedCount int
 
@@ -313,16 +304,93 @@ func TestBlockReplicator_ReConfig_AddPeer(t *testing.T) {
 		return env.AgreedLeaderIndex() >= 0
 	}
 	require.Eventually(t, isLeaderCond, 30*time.Second, 100*time.Millisecond)
+	leaderIdx := env.AgreedLeaderIndex()
 
-	block := &types.Block{
-		Header: &types.BlockHeader{
-			BaseHeader: &types.BlockHeaderBase{
-				Number:                1,
-				LastCommittedBlockNum: 1,
-			},
-		},
-		Payload: &types.Block_DataTxEnvelopes{},
+	numBlocks := uint64(10)
+	approxDataSize := 32
+	testSubmitDataBlocks(t, env, numBlocks, approxDataSize)
+
+	require.Eventually(t, func() bool { return env.AssertEqualHeight(numBlocks + 1) }, 30*time.Second, 100*time.Millisecond)
+
+	// a config tx that updates the membership by adding a 4th peer
+	next, updatedClusterConfig, proposeBlock := env.NextNodeConfig()
+	err := env.nodes[leaderIdx].blockReplicator.Submit(proposeBlock)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool { return env.AssertEqualHeight(numBlocks+2, 0, 1, 2) }, 30*time.Second, 100*time.Millisecond)
+	joinBlock, err := env.nodes[0].ledger.Get(numBlocks + 2)
+	require.NoError(t, err)
+	t.Logf("join-block: H: %+v, M: %+v", joinBlock.GetHeader(), joinBlock.GetConsensusMetadata())
+
+	// wait for some node to become a leader
+	isLeaderCond2 := func() bool {
+		return env.AgreedLeaderIndex(0, 1, 2) >= 0
 	}
+	require.Eventually(t, isLeaderCond2, 30*time.Second, 100*time.Millisecond)
+	require.Eventually(t, func() bool { return isCountOver(3) }, 30*time.Second, 100*time.Millisecond)
+
+	// start the new node
+	env.AddNode(t, next, updatedClusterConfig, joinBlock)
+	env.UpdateConfig()
+	err = env.nodes[next-1].Start()
+	require.NoError(t, err)
+	t.Logf("Started node: %d", next)
+
+	// wait for some node to become a leader, including the 4th node
+	require.Eventually(t, isLeaderCond, 30*time.Second, 100*time.Millisecond)
+
+	// make sure the 4th node created a snapshot from the join block
+	snapList := replication.ListSnapshots(env.nodes[next-1].conf.Logger, env.nodes[next-1].conf.LocalConf.Replication.SnapDir)
+	t.Logf("Snapshot list: %v", snapList)
+	require.True(t, len(snapList) == 1)
+	require.Equal(t, snapList[0], joinBlock.GetConsensusMetadata().GetRaftIndex())
+
+	// restart the new node, to check it can recover from the join-block snapshot
+	err = env.nodes[next-1].Close()
+	require.NoError(t, err)
+	err = env.nodes[next-1].Restart()
+	require.NoError(t, err)
+	t.Logf("Re-Started node: %d", next)
+
+	// wait for some node to become a leader, including the 4th node
+	require.Eventually(t, isLeaderCond, 30*time.Second, 100*time.Millisecond)
+
+	// submit a few blocks and check that all nodes got them, including the 4th node
+	testSubmitDataBlocks(t, env, numBlocks, approxDataSize)
+
+	t.Log("Closing")
+	for _, node := range env.nodes {
+		err := node.Close()
+		require.NoError(t, err)
+	}
+}
+
+// Scenario: add a peer to the cluster, with frequent snapshots
+// - start 3 nodes, configured to take frequent snapshots, wait for leader,
+// - submit a few blocks and verify reception by all, these blocks will create snapshots
+// - submit a config tx to adds a 4th peer, wait for all 3 to get it
+// - start the 4th peer with a join block derived from said config-tx
+// - submit a few blocks and check that all nodes got them, including the 4th node
+func TestBlockReplicator_ReConfig_AddPeer_WithSnapshots(t *testing.T) {
+	block, dataBlockLength := testDataBlock(2048)
+	raftConfig := proto.Clone(raftConfigNoSnapshots).(*types.RaftConfig)
+	raftConfig.SnapshotIntervalSize = 4 * dataBlockLength
+	t.Logf("configure frequent snapshots, 4x block size; block size: %d, SnapshotIntervalSize: %d", dataBlockLength, raftConfig.SnapshotIntervalSize)
+
+	env := createClusterEnv(t, 3, raftConfig, "info")
+	defer os.RemoveAll(env.testDir)
+	require.Equal(t, 3, len(env.nodes))
+
+	for _, node := range env.nodes {
+		err := node.Start()
+		require.NoError(t, err)
+	}
+
+	// wait for some node to become a leader
+	isLeaderCond := func() bool {
+		return env.AgreedLeaderIndex() >= 0
+	}
+	require.Eventually(t, isLeaderCond, 30*time.Second, 100*time.Millisecond)
 
 	leaderIdx := env.AgreedLeaderIndex()
 	numBlocks := uint64(10)
@@ -335,48 +403,186 @@ func TestBlockReplicator_ReConfig_AddPeer(t *testing.T) {
 	require.Eventually(t, func() bool { return env.AssertEqualHeight(numBlocks + 1) }, 30*time.Second, 100*time.Millisecond)
 
 	// a config tx that updates the membership by adding a 4th peer
-	updatedClusterConfig := proto.Clone(env.nodes[0].conf.ClusterConfig).(*types.ClusterConfig)
-	nodeConfig := &types.NodeConfig{
-		Id:          "node4",
-		Address:     "127.0.0.1",
-		Port:        nodePortBase + 4,
-		Certificate: []byte("bogus-cert"),
-	}
-	peerConfig := &types.PeerConfig{
-		NodeId:   "node4",
-		RaftId:   uint64(4),
-		PeerHost: "127.0.0.1",
-		PeerPort: peerPortBase + 4,
-	}
-	updatedClusterConfig.Nodes = append(updatedClusterConfig.Nodes, nodeConfig)
-	updatedClusterConfig.ConsensusConfig.Members = append(updatedClusterConfig.ConsensusConfig.Members, peerConfig)
-
-	proposeBlock := &types.Block{
-		Header: &types.BlockHeader{BaseHeader: &types.BlockHeaderBase{Number: 2}},
-		Payload: &types.Block_ConfigTxEnvelope{
-			ConfigTxEnvelope: &types.ConfigTxEnvelope{
-				Payload: &types.ConfigTx{
-					NewConfig: updatedClusterConfig,
-				},
-			},
-		},
-	}
+	next, updatedClusterConfig, proposeBlock := env.NextNodeConfig()
 	err := env.nodes[leaderIdx].blockReplicator.Submit(proposeBlock)
 	require.NoError(t, err)
 
-	require.Eventually(t, func() bool { return env.AssertEqualHeight(numBlocks + 2) }, 30*time.Second, 100*time.Millisecond)
+	require.Eventually(t, func() bool { return env.AssertEqualHeight(numBlocks+2, 0, 1, 2) }, 30*time.Second, 100*time.Millisecond)
+	joinBlock, err := env.nodes[0].ledger.Get(numBlocks + 2)
+	require.NoError(t, err)
+	t.Logf("join-block: H: %+v, M: %+v", joinBlock.GetHeader(), joinBlock.GetConsensusMetadata())
+	t.Logf("join-block: Config: %+v", joinBlock.GetPayload().(*types.Block_ConfigTxEnvelope).ConfigTxEnvelope.GetPayload().GetNewConfig())
 
 	// wait for some node to become a leader
 	isLeaderCond2 := func() bool {
 		return env.AgreedLeaderIndex(0, 1, 2) >= 0
 	}
 	require.Eventually(t, isLeaderCond2, 30*time.Second, 100*time.Millisecond)
-	require.Eventually(t, func() bool { return isCountOver(3) }, 30*time.Second, 100*time.Millisecond)
 
-	//TODO bootstrap a 4th node, see: https://github.com/hyperledger-labs/orion-server/issues/260
+	// start the new node
+	env.AddNode(t, next, updatedClusterConfig, joinBlock)
+	env.UpdateConfig()
+	err = env.nodes[next-1].Start()
+	require.NoError(t, err)
+	t.Logf("Started node: %d", next)
+
+	// wait for some node to become a leader, including the 4th node
+	require.Eventually(t, isLeaderCond, 30*time.Second, 100*time.Millisecond)
+
+	// submit few blocks and check that all nodes got them, including the 4th node
+	leaderIdx = env.AgreedLeaderIndex()
+	for i := uint64(0); i < 1; i++ {
+		b := proto.Clone(block).(*types.Block)
+		err := env.nodes[leaderIdx].blockReplicator.Submit(b)
+		require.NoError(t, err)
+	}
+	require.Eventually(t, func() bool { return env.AssertEqualHeight(numBlocks + 3) }, 5*time.Second, 100*time.Millisecond)
+
 	t.Log("Closing")
 	for _, node := range env.nodes {
 		err := node.Close()
 		require.NoError(t, err)
 	}
+}
+
+// Scenario: add and remove nodes until original IDs are all removed
+func TestBlockReplicator_ReConfig_AddRemovePeersRolling(t *testing.T) {
+	approxDataSize := 32
+	numBlocks := uint64(10)
+
+	env := createClusterEnv(t, 3, nil, "info")
+	defer os.RemoveAll(env.testDir)
+	require.Equal(t, 3, len(env.nodes))
+
+	for _, node := range env.nodes {
+		err := node.Start()
+		require.NoError(t, err)
+	}
+
+	// wait for some node to become a leader
+	require.Eventually(t, func() bool { return env.AgreedLeaderIndex() >= 0 }, 30*time.Second, 100*time.Millisecond)
+
+	testSubmitDataBlocks(t, env, numBlocks, approxDataSize, 0, 1, 2)
+
+	// === add 4th node ===
+	testRollingAddNode(t, env, 0, 1, 2)
+
+	// === remove the 1st node ===
+	testRollingRemoveNode(t, env, 0, 1, 2, 3)
+
+	// === add 5th node ===
+	testRollingAddNode(t, env, 1, 2, 3)
+
+	// === remove the 2nd node ===
+	testRollingRemoveNode(t, env, 1, 2, 3, 4)
+
+	// === remove the 3nd node ===
+	testRollingRemoveNode(t, env, 2, 3, 4)
+
+	// === add 6th node ===
+	testRollingAddNode(t, env, 3, 4)
+
+	t.Log("Closing")
+	for idx := 3; idx <= 5; idx++ {
+		err := env.nodes[idx].Close()
+		require.NoError(t, err)
+	}
+}
+
+// Scenario: add and remove nodes until original IDs are all removed, with frequent snapshots
+func TestBlockReplicator_ReConfig_AddRemovePeersRolling_WithSnapshots(t *testing.T) {
+	approxDataSize := 2048
+	numBlocks := uint64(10)
+	_, dataBlockLength := testDataBlock(approxDataSize)
+	raftConfig := proto.Clone(raftConfigNoSnapshots).(*types.RaftConfig)
+	raftConfig.SnapshotIntervalSize = 4 * dataBlockLength
+	t.Logf("configure frequent snapshots, 4x block size; block size: %d, SnapshotIntervalSize: %d", dataBlockLength, raftConfig.SnapshotIntervalSize)
+
+	env := createClusterEnv(t, 3, raftConfig, "info")
+	defer os.RemoveAll(env.testDir)
+	require.Equal(t, 3, len(env.nodes))
+
+	for _, node := range env.nodes {
+		err := node.Start()
+		require.NoError(t, err)
+	}
+
+	// wait for some node to become a leader
+	require.Eventually(t, func() bool { return env.AgreedLeaderIndex() >= 0 }, 30*time.Second, 100*time.Millisecond)
+
+	testSubmitDataBlocks(t, env, numBlocks, approxDataSize)
+
+	// === add 4th node ===
+	testRollingAddNode(t, env, 0, 1, 2)
+
+	// === remove the 1st node ===
+	testRollingRemoveNode(t, env, 0, 1, 2, 3)
+
+	// === add 5th node ===
+	testRollingAddNode(t, env, 1, 2, 3)
+
+	// === remove the 2nd node
+	testRollingRemoveNode(t, env, 1, 2, 3, 4)
+
+	// === remove the 3nd node
+	testRollingRemoveNode(t, env, 2, 3, 4)
+
+	// === add 6th node ===
+	testRollingAddNode(t, env, 3, 4)
+
+	t.Log("Closing")
+	for idx := 3; idx <= 5; idx++ {
+		err := env.nodes[idx].Close()
+		require.NoError(t, err)
+	}
+}
+
+func testRollingAddNode(t *testing.T, env *clusterEnv, indicesBefore ...int) {
+	leaderIdx := env.AgreedLeaderIndex(indicesBefore...)
+	heightBefore, err := env.nodes[leaderIdx].ledger.Height()
+	require.NoError(t, err)
+
+	// a config tx that updates the membership by adding a peer
+	nextID, updatedClusterConfig, proposeBlock := env.NextNodeConfig()
+	err = env.nodes[leaderIdx].blockReplicator.Submit(proposeBlock)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool { return env.AssertEqualHeight(heightBefore+1, indicesBefore...) }, 30*time.Second, 100*time.Millisecond)
+	joinBlock, err := env.nodes[leaderIdx].ledger.Get(heightBefore + 1)
+	require.NoError(t, err)
+	t.Logf("Adding node: %d, join-block: H: %+v, M: %+v", nextID, joinBlock.GetHeader(), joinBlock.GetConsensusMetadata())
+
+	// wait for some node to become a leader
+	require.Eventually(t, func() bool { return env.AgreedLeaderIndex(indicesBefore...) >= 0 }, 30*time.Second, 100*time.Millisecond)
+
+	// start the new node
+	env.AddNode(t, nextID, updatedClusterConfig, joinBlock)
+	env.UpdateConfig()
+	err = env.nodes[nextID-1].Start()
+	require.NoError(t, err)
+	t.Logf("Started node: %d", nextID)
+
+	// wait for some node to become a leader, including the added node
+	indicesAfter := append(indicesBefore, int(nextID-1))
+	require.Eventually(t, func() bool { return env.AgreedLeaderIndex(indicesAfter...) >= 0 }, 30*time.Second, 100*time.Millisecond)
+	require.Eventually(t, func() bool { return env.AssertEqualHeight(heightBefore+1, indicesAfter...) }, 30*time.Second, 100*time.Millisecond)
+}
+
+func testRollingRemoveNode(t *testing.T, env *clusterEnv, removeIdx int, indicesAfter ...int) {
+	err := env.nodes[removeIdx].Close()
+	require.NoError(t, err)
+	t.Logf("Closed node: %d", removeIdx+1)
+
+	require.Eventually(t, func() bool { return env.AgreedLeaderIndex(indicesAfter...) >= 0 }, 30*time.Second, 100*time.Millisecond)
+	leaderIdx := env.AgreedLeaderIndex(indicesAfter...)
+	heightBefore, err := env.nodes[leaderIdx].ledger.Height()
+	require.NoError(t, err)
+
+	_, proposeBlock := env.RemoveFirstNodeConfig()
+	err = env.nodes[leaderIdx].blockReplicator.Submit(proposeBlock)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return env.AssertEqualHeight(heightBefore+1, indicesAfter...) }, 30*time.Second, 100*time.Millisecond)
+	require.Eventually(t, func() bool { return env.AgreedLeaderIndex(indicesAfter...) >= 0 }, 30*time.Second, 100*time.Millisecond)
+	leaderIdx = env.AgreedLeaderIndex(indicesAfter...)
+	t.Logf("Removed node: %d, leader is: %d", removeIdx+1, leaderIdx)
 }

--- a/internal/replication/blockreplicator_test.go
+++ b/internal/replication/blockreplicator_test.go
@@ -381,7 +381,6 @@ func TestBlockReplicator_Submit(t *testing.T) {
 // Scenario: check that a config block is allowed to commit, if
 // - it carries admin updates, or
 // - it carries CA updates.
-// TODO changing consensus/node config is not yet supported.
 func TestBlockReplicator_ReConfig(t *testing.T) {
 	t.Run("update admins", func(t *testing.T) {
 		env := createNodeEnv(t, "info")

--- a/internal/replication/raft_http_error.go
+++ b/internal/replication/raft_http_error.go
@@ -1,0 +1,30 @@
+package replication
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// RaftHTTPError is used when replication needs to send an error response to a raft request
+type RaftHTTPError struct {
+	Message string
+	Code    int
+}
+
+func (e *RaftHTTPError) Error() string {
+	return fmt.Sprintf("%s (%d)", e.Message, e.Code)
+}
+
+func (e *RaftHTTPError) WriteTo(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(e.Code)
+	b, err := json.Marshal(e)
+	if err != nil {
+		panic(fmt.Sprintf("marshal RaftHTTPError should never fail: %s", err.Error()))
+	}
+
+	_, _ = w.Write(b)
+	
+	return
+}


### PR DESCRIPTION
 A new node in the cluster bootstraps with a join block, which is a config block that includes it in the Nodes and Members arrays.
    
The new nodes initializes comm.HTTPTransport with the peers from the join block, and therefore  can reach all the current active peers.
    
The node starts by on-boarding, that is, fetching all the blocks from 1 (genesis) and the  join-block number (say, J). As it receives blocks, it commits them to the ledger and databases,     rebuilding the state. If the node crashes befor reaching block J, it will resume on-boarding from where it stopped.
    
When the node reaches the join-block, it uses the cluster config within to construct a raftpb.ConfState,     it reads the raft Index and Term, and initializes the raft-storage (WAL & memory) to signal to raft     that it had caught up until said raft.Index, and saves a snapshot. 
    
It then starts the raft node and continues as normal.
