### PR TITLE
Separate tx validation from block processor

### DIFF
--- a/internal/bcdb/transaction_processor.go
+++ b/internal/bcdb/transaction_processor.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hyperledger-labs/orion-server/internal/queue"
 	"github.com/hyperledger-labs/orion-server/internal/replication"
 	"github.com/hyperledger-labs/orion-server/internal/txreorderer"
+	"github.com/hyperledger-labs/orion-server/internal/txvalidation"
 	"github.com/hyperledger-labs/orion-server/internal/worldstate"
 	"github.com/hyperledger-labs/orion-server/pkg/constants"
 	"github.com/hyperledger-labs/orion-server/pkg/logger"
@@ -80,6 +81,15 @@ func newTransactionProcessor(conf *txProcessorConfig) (*transactionProcessor, er
 
 	var err error
 
+	//TODO provide the txValidator to pre-order components that need it, e.g. block-replicator
+	// see: https://github.com/hyperledger-labs/orion-server/issues/280
+	txValidator := txvalidation.NewValidator(
+		&txvalidation.Config{
+			DB:     conf.db,
+			Logger: conf.logger,
+		},
+	)
+
 	p.blockProcessor = blockprocessor.New(
 		&blockprocessor.Config{
 			BlockOneQueueBarrier: p.blockOneQueueBarrier,
@@ -87,6 +97,7 @@ func newTransactionProcessor(conf *txProcessorConfig) (*transactionProcessor, er
 			ProvenanceStore:      conf.provenanceStore,
 			StateTrieStore:       conf.stateTrieStore,
 			DB:                   conf.db,
+			TxValidator:          txValidator,
 			Logger:               conf.logger,
 		},
 	)

--- a/internal/blockprocessor/committer.go
+++ b/internal/blockprocessor/committer.go
@@ -602,16 +602,3 @@ func constructProvenanceEntriesForConfigTx(
 		nodesPData,
 	}, nil
 }
-
-func getVersion(
-	dbName, key string,
-	dirtyWriteKeyVersion map[string]*types.Version,
-	db worldstate.DB,
-) (*types.Version, error) {
-	version, ok := dirtyWriteKeyVersion[constructCompositeKey(dbName, key)]
-	if ok {
-		return version, nil
-	}
-
-	return db.GetVersion(dbName, key)
-}

--- a/internal/blockprocessor/committer_test.go
+++ b/internal/blockprocessor/committer_test.go
@@ -659,10 +659,10 @@ func TestStateDBCommitterForUserBlock(t *testing.T) {
 		{
 			name: "add and delete users",
 			setup: func(env *committerTestEnv) {
-				user1 := constructUserForTest(t, "user1", nil, nil, sampleVersion, nil)
-				user2 := constructUserForTest(t, "user2", nil, nil, sampleVersion, nil)
-				user3 := constructUserForTest(t, "user3", nil, nil, sampleVersion, nil)
-				user4 := constructUserForTest(t, "user4", nil, nil, sampleVersion, nil)
+				user1 := constructUserForTest(t, "user1", sampleVersion)
+				user2 := constructUserForTest(t, "user2", sampleVersion)
+				user3 := constructUserForTest(t, "user3", sampleVersion)
+				user4 := constructUserForTest(t, "user4", sampleVersion)
 				users := map[string]*worldstate.DBUpdates{
 					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
@@ -753,7 +753,7 @@ func TestStateDBCommitterForUserBlock(t *testing.T) {
 				users := map[string]*worldstate.DBUpdates{
 					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
-							constructUserForTest(t, "user1", nil, nil, sampleVersion, nil),
+							constructUserForTest(t, "user1", sampleVersion),
 						},
 					},
 				}
@@ -1871,7 +1871,7 @@ func TestProvenanceStoreCommitterForUserBlockWithValidTxs(t *testing.T) {
 		BlockNum: 1,
 		TxNum:    0,
 	}
-	user1 := constructUserForTest(t, "user1", []byte("rawcert-user1"), nil, sampleVersion, nil)
+	user1 := constructUserForTest(t, "user1", sampleVersion)
 	rawUser1New := &types.User{
 		Id:          "user1",
 		Certificate: []byte("rawcert-user1-new"),
@@ -3000,4 +3000,22 @@ func constructPeerEntryForTest(id uint64) *types.PeerConfig {
 		PeerHost: "192.168.0.6",
 		PeerPort: uint32(20000 + id),
 	}
+}
+
+func constructUserForTest(t *testing.T, userID string, version *types.Version) *worldstate.KVWithMetadata {
+	user := &types.User{
+		Id: userID,
+	}
+	userSerialized, err := proto.Marshal(user)
+	require.NoError(t, err)
+
+	userEntry := &worldstate.KVWithMetadata{
+		Key:   string(identity.UserNamespace) + userID,
+		Value: userSerialized,
+		Metadata: &types.Metadata{
+			Version: version,
+		},
+	}
+
+	return userEntry
 }

--- a/internal/txvalidation/config_tx_validator.go
+++ b/internal/txvalidation/config_tx_validator.go
@@ -1,7 +1,7 @@
 // Copyright IBM Corp. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package blockprocessor
+package txvalidation
 
 import (
 	"fmt"
@@ -27,7 +27,7 @@ type configTxValidator struct {
 	logger          *logger.SugarLogger
 }
 
-func (v *configTxValidator) validate(txEnv *types.ConfigTxEnvelope) (*types.ValidationInfo, error) {
+func (v *configTxValidator) Validate(txEnv *types.ConfigTxEnvelope) (*types.ValidationInfo, error) {
 	valInfo, err := v.sigValidator.validate(txEnv.Payload.UserId, txEnv.Signature, txEnv.Payload)
 	if err != nil || valInfo.Flag != types.Flag_VALID {
 		return valInfo, err

--- a/internal/txvalidation/config_tx_validator_test.go
+++ b/internal/txvalidation/config_tx_validator_test.go
@@ -1,6 +1,7 @@
 // Copyright IBM Corp. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-package blockprocessor
+
+package txvalidation
 
 import (
 	"strings"
@@ -590,7 +591,7 @@ func TestValidateConfigTx(t *testing.T) {
 
 			setup(env.db)
 
-			result, err := env.validator.configTxValidator.validate(tt.txEnv)
+			result, err := env.validator.configTxValidator.Validate(tt.txEnv)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedResult, result)
 		})

--- a/internal/txvalidation/data_tx_validator.go
+++ b/internal/txvalidation/data_tx_validator.go
@@ -1,16 +1,17 @@
 // Copyright IBM Corp. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-package blockprocessor
+
+package txvalidation
 
 import (
 	"sort"
 	"strings"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger-labs/orion-server/internal/identity"
 	"github.com/hyperledger-labs/orion-server/internal/worldstate"
 	"github.com/hyperledger-labs/orion-server/pkg/logger"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
-	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 )
 

--- a/internal/txvalidation/data_tx_validator_test.go
+++ b/internal/txvalidation/data_tx_validator_test.go
@@ -1,16 +1,17 @@
 // Copyright IBM Corp. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-package blockprocessor
+
+package txvalidation
 
 import (
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger-labs/orion-server/internal/identity"
 	"github.com/hyperledger-labs/orion-server/internal/worldstate"
 	"github.com/hyperledger-labs/orion-server/pkg/crypto"
 	"github.com/hyperledger-labs/orion-server/pkg/server/testutils"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
-	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/txvalidation/dbadmin_tx_validator.go
+++ b/internal/txvalidation/dbadmin_tx_validator.go
@@ -1,6 +1,7 @@
 // Copyright IBM Corp. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-package blockprocessor
+
+package txvalidation
 
 import (
 	"github.com/hyperledger-labs/orion-server/internal/identity"

--- a/internal/txvalidation/dbadmin_tx_validator_test.go
+++ b/internal/txvalidation/dbadmin_tx_validator_test.go
@@ -1,15 +1,16 @@
 // Copyright IBM Corp. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-package blockprocessor
+
+package txvalidation
 
 import (
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger-labs/orion-server/internal/identity"
 	"github.com/hyperledger-labs/orion-server/internal/worldstate"
 	"github.com/hyperledger-labs/orion-server/pkg/server/testutils"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
-	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/txvalidation/sig_validator.go
+++ b/internal/txvalidation/sig_validator.go
@@ -1,6 +1,7 @@
 // Copyright IBM Corp. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-package blockprocessor
+
+package txvalidation
 
 import (
 	"encoding/json"

--- a/internal/txvalidation/useradmin_tx_validator.go
+++ b/internal/txvalidation/useradmin_tx_validator.go
@@ -1,14 +1,15 @@
 // Copyright IBM Corp. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-package blockprocessor
+
+package txvalidation
 
 import (
+	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger-labs/orion-server/internal/identity"
 	"github.com/hyperledger-labs/orion-server/internal/worldstate"
 	"github.com/hyperledger-labs/orion-server/pkg/certificateauthority"
 	"github.com/hyperledger-labs/orion-server/pkg/logger"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
-	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 )
 

--- a/internal/txvalidation/useradmin_tx_validator_test.go
+++ b/internal/txvalidation/useradmin_tx_validator_test.go
@@ -1,16 +1,17 @@
 // Copyright IBM Corp. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-package blockprocessor
+
+package txvalidation
 
 import (
 	"crypto/x509"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger-labs/orion-server/internal/identity"
 	"github.com/hyperledger-labs/orion-server/internal/worldstate"
 	"github.com/hyperledger-labs/orion-server/pkg/server/testutils"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
-	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
In preparation for implementing config-tx validation pre-order (future commit), we separate the tx-validation logic into a separate package.
    - All validation code was moved to a new package
    - Respective types & methods used in other packages made Public (e.g. ValidateBlock)
    - The block processor consumes a single method during commit: 'ValidateBlock'.
    - Generation of Validator extracted from inside the block processor, now in transaction processor
    - Validator now can be shared with other components (future commit)
    
The block processor consumes a single method during commit: 'ValidateBlock'.
    
This will make it easier to expose validation logic to pre-ordering components.
    
This commit presents **no functional change**, just refactoring of existing code.
