### PR TITLE
HTTPTransport reports active peers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.7.0
 	github.com/syndtr/goleveldb v1.0.0
+	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20210226220824-aa7126864d82 // indirect git tag v3.4.15
 	go.uber.org/zap v1.18.1
 	gopkg.in/yaml.v2 v2.2.8 // indirect

--- a/internal/replication/blockreplicator_reconfig_test.go
+++ b/internal/replication/blockreplicator_reconfig_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -21,12 +20,34 @@ import (
 
 // Scenario: reconfigure a node endpoint
 // - start 3 nodes, submit some blocks, verify replication
-// - restart node 3 on another endpoint, not yet reflected in the shared-config, node is partitioned from raft
+// - stop node 3
 // - submit some blocks, verify replication on 2 nodes
-// - submit a config-tx that reflects the 3rd node new PeerConfig
+// - submit a config-tx that reflects the 3rd node new PeerConfig, a changed endpoint 127.0.0.1:23004
+// - restart node 3 on the new endpoint
 // - verify 3rd node is back to the cluster and catches up.
 func TestBlockReplicator_ReConfig_Endpoint(t *testing.T) {
-	env := createClusterEnv(t, 3, nil, "info")
+	var countMutex sync.Mutex
+	var updatedCount int
+
+	isCountEqual := func(num int) bool {
+		countMutex.Lock()
+		defer countMutex.Unlock()
+
+		return updatedCount == num
+	}
+
+	clusterConfigHook := func(entry zapcore.Entry) error {
+		if strings.Contains(entry.Message, "New cluster config committed, going to apply to block replicator:") &&
+			strings.Contains(entry.Message, "peer_port:23004") {
+			countMutex.Lock()
+			defer countMutex.Unlock()
+
+			updatedCount++
+		}
+		return nil
+	}
+
+	env := createClusterEnv(t, 3, nil, "info", zap.Hooks(clusterConfigHook))
 	defer os.RemoveAll(env.testDir)
 	require.Equal(t, 3, len(env.nodes))
 
@@ -39,7 +60,7 @@ func TestBlockReplicator_ReConfig_Endpoint(t *testing.T) {
 	isLeaderCond := func() bool {
 		return env.AgreedLeaderIndex() >= 0
 	}
-	assert.Eventually(t, isLeaderCond, 30*time.Second, 100*time.Millisecond)
+	require.Eventually(t, isLeaderCond, 30*time.Second, 100*time.Millisecond)
 
 	block := &types.Block{
 		Header: &types.BlockHeader{
@@ -68,22 +89,19 @@ func TestBlockReplicator_ReConfig_Endpoint(t *testing.T) {
 		require.EqualError(t, err, expectedNotLeaderErr)
 	}
 
-	assert.Eventually(t, func() bool { return env.AssertEqualHeight(numBlocks + 1) }, 30*time.Second, 100*time.Millisecond)
+	require.Eventually(t, func() bool { return env.AssertEqualHeight(numBlocks + 1) }, 30*time.Second, 100*time.Millisecond)
 
-	// restart node 3 on a new port, it will be partitioned from Raft
+	// stop node 3
 	env.nodes[2].Close()
-	env.nodes[2].conf.LocalConf.Replication.Network.Port++
-	env.nodes[2].Restart()
 
 	// wait for some node [1,2] to become a leader
 	isLeaderCond2 := func() bool {
 		return env.AgreedLeaderIndex(0, 1) >= 0
 	}
-	assert.Eventually(t, isLeaderCond2, 30*time.Second, 100*time.Millisecond)
+	require.Eventually(t, isLeaderCond2, 30*time.Second, 100*time.Millisecond)
 	leaderIdx = env.AgreedLeaderIndex(0, 1)
 	expectedNotLeaderErr = fmt.Sprintf("not a leader, leader is RaftID: %d, with HostPort: 127.0.0.1:2200%d", leaderIdx+1, leaderIdx+1)
 	follower1 = (leaderIdx + 1) % 2
-	follower2 = 2
 	for i := numBlocks; i < 2*numBlocks; i++ {
 		b := proto.Clone(block).(*types.Block)
 		err := env.nodes[leaderIdx].blockReplicator.Submit(b)
@@ -91,19 +109,14 @@ func TestBlockReplicator_ReConfig_Endpoint(t *testing.T) {
 
 		// submission to a follower will cause an error
 		err = env.nodes[follower1].blockReplicator.Submit(b)
-		assert.EqualError(t, err, expectedNotLeaderErr)
-		// submission to a partitioned node will cause an error
-		err = env.nodes[follower2].blockReplicator.Submit(b)
-		assert.EqualError(t, err, "not a leader, leader is RaftID: 0, with HostPort: ")
+		require.EqualError(t, err, expectedNotLeaderErr)
 	}
 
-	// nodes [1,2] are in sync, node 3 is partitioned
-	assert.Eventually(t, func() bool { return env.AssertEqualHeight(2*numBlocks+1, 0, 1) }, 30*time.Second, 100*time.Millisecond)
-	h3, err := env.nodes[2].ledger.Height()
-	require.NoError(t, err)
-	assert.Equal(t, numBlocks+1, h3)
+	// nodes [1,2] are in sync, node 3 is down
+	require.Eventually(t, func() bool { return env.AssertEqualHeight(2*numBlocks+1, 0, 1) }, 30*time.Second, 100*time.Millisecond)
 
 	// a config tx that updates the two running members
+	env.nodes[2].conf.LocalConf.Replication.Network.Port++ // this will be the new port of node 3
 	clusterConfig := proto.Clone(env.nodes[0].conf.ClusterConfig).(*types.ClusterConfig)
 	clusterConfig.ConsensusConfig.Members[2].PeerPort = env.nodes[2].conf.LocalConf.Replication.Network.Port
 	proposeBlock := &types.Block{
@@ -116,13 +129,34 @@ func TestBlockReplicator_ReConfig_Endpoint(t *testing.T) {
 			},
 		},
 	}
-	err = env.nodes[leaderIdx].blockReplicator.Submit(proposeBlock)
+	err := env.nodes[leaderIdx].blockReplicator.Submit(proposeBlock)
 	require.NoError(t, err)
+	require.Eventually(t, func() bool { return isCountEqual(2) }, 30*time.Second, 100*time.Millisecond)
+	require.Eventually(t, func() bool { return env.AssertEqualHeight(2*numBlocks+2, 0, 1) }, 30*time.Second, 100*time.Millisecond)
 
-	// after re-config node3 is no longer partitioned from the cluster, catches up, and knows who the leader is
-	assert.Eventually(t, func() bool { return env.AssertEqualHeight(2*numBlocks + 2) }, 30*time.Second, 100*time.Millisecond)
-	err = env.nodes[follower2].blockReplicator.Submit(proto.Clone(block).(*types.Block))
-	assert.EqualError(t, err, expectedNotLeaderErr)
+	countMutex.Lock()
+	updatedCount = 0
+	countMutex.Unlock()
+
+	// restart node 3 on a new port
+	env.nodes[2].Restart()
+
+	// after re-config node3 catches up, and knows who the leader is
+	require.Eventually(t, func() bool { return isCountEqual(1) }, 30*time.Second, 100*time.Millisecond)
+	require.Eventually(t, func() bool { return env.AssertEqualHeight(2*numBlocks + 2) }, 30*time.Second, 100*time.Millisecond)
+
+	for i := 0; i < 3; i++ {
+		var activePeers map[string]*types.PeerConfig
+		require.Eventually(t,
+			func() bool {
+				activePeers = env.nodes[i].conf.Transport.ActivePeers(10*time.Millisecond, true)
+				return len(activePeers) == 3
+			},
+			10*time.Second, 1000*time.Millisecond)
+		require.Equal(t, "node3", activePeers["node3"].NodeId)
+		require.Equal(t, "node2", activePeers["node2"].NodeId)
+		require.Equal(t, "node1", activePeers["node1"].NodeId)
+	}
 
 	t.Log("Closing")
 	for _, node := range env.nodes {
@@ -187,7 +221,7 @@ func testReConfigPeerRemoveBefore(t *testing.T, env *clusterEnv, numBlocks uint6
 	isLeaderCond := func() bool {
 		return env.AgreedLeaderIndex() >= 0
 	}
-	assert.Eventually(t, isLeaderCond, 30*time.Second, 100*time.Millisecond)
+	require.Eventually(t, isLeaderCond, 30*time.Second, 100*time.Millisecond)
 
 	block := &types.Block{
 		Header: &types.BlockHeader{
@@ -206,7 +240,7 @@ func testReConfigPeerRemoveBefore(t *testing.T, env *clusterEnv, numBlocks uint6
 		require.NoError(t, err)
 	}
 
-	assert.Eventually(t, func() bool { return env.AssertEqualHeight(numBlocks + 1) }, 30*time.Second, 100*time.Millisecond)
+	require.Eventually(t, func() bool { return env.AssertEqualHeight(numBlocks + 1) }, 30*time.Second, 100*time.Millisecond)
 	return leaderIdx
 }
 
@@ -231,7 +265,7 @@ func testReConfigPeerRemovePropose(t *testing.T, env *clusterEnv, leaderIdx, rem
 
 	err := env.nodes[leaderIdx].blockReplicator.Submit(proposeBlock)
 	require.NoError(t, err)
-	assert.Eventually(t, func() bool { return env.AssertEqualHeight(numBlocks + 2) }, 30*time.Second, 100*time.Millisecond)
+	require.Eventually(t, func() bool { return env.AssertEqualHeight(numBlocks + 2) }, 30*time.Second, 100*time.Millisecond)
 }
 
 func testReConfigPeerRemoveAfter(t *testing.T, env *clusterEnv, removePeerIdx int, remainingPeers []int) {
@@ -239,14 +273,14 @@ func testReConfigPeerRemoveAfter(t *testing.T, env *clusterEnv, removePeerIdx in
 	isLeaderCond2 := func() bool {
 		return env.AgreedLeaderIndex(remainingPeers...) >= 0
 	}
-	assert.Eventually(t, isLeaderCond2, 30*time.Second, 100*time.Millisecond)
+	require.Eventually(t, isLeaderCond2, 30*time.Second, 100*time.Millisecond)
 
 	// make sure the removed node had detached from the cluster
 	removedHasNoLeader := func() bool {
 		err := env.nodes[removePeerIdx].blockReplicator.IsLeader()
 		return err.Error() == "not a leader, leader is RaftID: 0, with HostPort: "
 	}
-	assert.Eventually(t, removedHasNoLeader, 10*time.Second, 100*time.Millisecond)
+	require.Eventually(t, removedHasNoLeader, 10*time.Second, 100*time.Millisecond)
 
 	t.Log("Closing")
 	for _, node := range env.nodes {
@@ -290,7 +324,7 @@ func TestBlockReplicator_ReConfig_AddPeer(t *testing.T) {
 	isLeaderCond := func() bool {
 		return env.AgreedLeaderIndex() >= 0
 	}
-	assert.Eventually(t, isLeaderCond, 30*time.Second, 100*time.Millisecond)
+	require.Eventually(t, isLeaderCond, 30*time.Second, 100*time.Millisecond)
 
 	block := &types.Block{
 		Header: &types.BlockHeader{
@@ -310,7 +344,7 @@ func TestBlockReplicator_ReConfig_AddPeer(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	assert.Eventually(t, func() bool { return env.AssertEqualHeight(numBlocks + 1) }, 30*time.Second, 100*time.Millisecond)
+	require.Eventually(t, func() bool { return env.AssertEqualHeight(numBlocks + 1) }, 30*time.Second, 100*time.Millisecond)
 
 	// a config tx that updates the membership by adding a 4th peer
 	updatedClusterConfig := proto.Clone(env.nodes[0].conf.ClusterConfig).(*types.ClusterConfig)
@@ -342,14 +376,14 @@ func TestBlockReplicator_ReConfig_AddPeer(t *testing.T) {
 	err := env.nodes[leaderIdx].blockReplicator.Submit(proposeBlock)
 	require.NoError(t, err)
 
-	assert.Eventually(t, func() bool { return env.AssertEqualHeight(numBlocks + 2) }, 30*time.Second, 100*time.Millisecond)
+	require.Eventually(t, func() bool { return env.AssertEqualHeight(numBlocks + 2) }, 30*time.Second, 100*time.Millisecond)
 
 	// wait for some node to become a leader
 	isLeaderCond2 := func() bool {
 		return env.AgreedLeaderIndex(0, 1, 2) >= 0
 	}
-	assert.Eventually(t, isLeaderCond2, 30*time.Second, 100*time.Millisecond)
-	assert.Eventually(t, func() bool { return isCountOver(3) }, 30*time.Second, 100*time.Millisecond)
+	require.Eventually(t, isLeaderCond2, 30*time.Second, 100*time.Millisecond)
+	require.Eventually(t, func() bool { return isCountOver(3) }, 30*time.Second, 100*time.Millisecond)
 
 	//TODO bootstrap a 4th node, see: https://github.com/hyperledger-labs/orion-server/issues/260
 	t.Log("Closing")


### PR DESCRIPTION
1. Utilize the rafthttp transport method that reports active peers.
2. Register the raft endpoints correctly to the ServeMux.
3. Expose a new method comm.HTTPTransport.ActivePeers, this will be used in the API that reports the cluster status (future commit).
4. Correct unit tests in comm and replication in light of the fix in (2).

After registering the raft endpoints correctly (2), the nodes may connect in an asymmetric way, that is:
- say the shared cluster config defines: (node1  localhost:1001) (node2  localhost:1002) (node3 localhost:1003)
- and: node1 binds to 1001, node2 binds to 1002
- but: node3 binds to 1004
- then: the connectivity is asymmetric - node3 can reach node1 & node2 but not the other way around

This may happen when reconfiguring an endpoint: node3 from 1003 -> 1004; and if
- node3 restarts on the new port before the config-tx, or
- it is kept alive during config-tx and restarted later.

The correct procedure for node endpoint update is to stop the node, reconfigure the remaining, and start it on the new port.

The tests were updated accordingly.

Signed-off-by: Yoav Tock <tock@il.ibm.com>