### PR TITLE
Rename httputils package to utils

### DIFF
--- a/config/join_block.go
+++ b/config/join_block.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/hyperledger-labs/orion-server/internal/httputils"
+	"github.com/hyperledger-labs/orion-server/internal/utils"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
 	"github.com/pkg/errors"
 )
@@ -37,7 +37,7 @@ func readJoinBlock(joinBlockFile string) (*types.Block, error) {
 		return nil, errors.Errorf("join block number is 0, file: %s", joinBlockFile)
 	}
 
-	if !httputils.IsConfigBlock(block) {
+	if !utils.IsConfigBlock(block) {
 		return nil, errors.Errorf("join block is not a config block, file: %s", joinBlockFile)
 	}
 

--- a/config/join_block_test.go
+++ b/config/join_block_test.go
@@ -7,7 +7,7 @@ import (
 	"path"
 	"testing"
 
-	"github.com/hyperledger-labs/orion-server/internal/httputils"
+	"github.com/hyperledger-labs/orion-server/internal/utils"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
 	"github.com/stretchr/testify/require"
 )
@@ -43,7 +43,7 @@ func TestJoinBlock(t *testing.T) {
 
 	t.Run("bad block: no header", func(t *testing.T) {
 		joinBlockPath := path.Join(dir, "bad-cluster-join-1.block")
-		blockBytes := httputils.MarshalOrPanic(&types.Block{})
+		blockBytes := utils.MarshalOrPanic(&types.Block{})
 		ioutil.WriteFile(joinBlockPath, blockBytes, 0666)
 		joinBlock, err := readJoinBlock(joinBlockPath)
 		expectedErr := fmt.Sprintf("join block header is empty, file: %s", joinBlockPath)
@@ -53,7 +53,7 @@ func TestJoinBlock(t *testing.T) {
 
 	t.Run("bad block: no base header", func(t *testing.T) {
 		joinBlockPath := path.Join(dir, "bad-cluster-join-2.block")
-		blockBytes := httputils.MarshalOrPanic(&types.Block{
+		blockBytes := utils.MarshalOrPanic(&types.Block{
 			Header: &types.BlockHeader{},
 		})
 		ioutil.WriteFile(joinBlockPath, blockBytes, 0666)
@@ -65,7 +65,7 @@ func TestJoinBlock(t *testing.T) {
 
 	t.Run("bad block: no number", func(t *testing.T) {
 		joinBlockPath := path.Join(dir, "bad-cluster-join-3.block")
-		blockBytes := httputils.MarshalOrPanic(&types.Block{
+		blockBytes := utils.MarshalOrPanic(&types.Block{
 			Header: &types.BlockHeader{
 				BaseHeader: &types.BlockHeaderBase{},
 			},
@@ -79,7 +79,7 @@ func TestJoinBlock(t *testing.T) {
 
 	t.Run("bad block: not a config block", func(t *testing.T) {
 		joinBlockPath := path.Join(dir, "bad-cluster-join-4.block")
-		blockBytes := httputils.MarshalOrPanic(&types.Block{
+		blockBytes := utils.MarshalOrPanic(&types.Block{
 			Header: &types.BlockHeader{
 				BaseHeader: &types.BlockHeaderBase{Number: 10},
 			},
@@ -99,7 +99,7 @@ func TestJoinBlock(t *testing.T) {
 			},
 			Payload: &types.Block_ConfigTxEnvelope{},
 		}
-		blockBytes := httputils.MarshalOrPanic(block)
+		blockBytes := utils.MarshalOrPanic(block)
 		ioutil.WriteFile(joinBlockPath, blockBytes, 0666)
 		joinBlock, err := readJoinBlock(joinBlockPath)
 		expectedErr := fmt.Sprintf("join block config-tx envelope is empty or nil, file: %s", joinBlockPath)
@@ -107,7 +107,7 @@ func TestJoinBlock(t *testing.T) {
 		require.Nil(t, joinBlock)
 
 		block.Payload.(*types.Block_ConfigTxEnvelope).ConfigTxEnvelope = &types.ConfigTxEnvelope{}
-		blockBytes = httputils.MarshalOrPanic(block)
+		blockBytes = utils.MarshalOrPanic(block)
 		ioutil.WriteFile(joinBlockPath, blockBytes, 0666)
 		joinBlock, err = readJoinBlock(joinBlockPath)
 		require.EqualError(t, err, expectedErr)
@@ -116,7 +116,7 @@ func TestJoinBlock(t *testing.T) {
 
 	t.Run("bad block: no new-config", func(t *testing.T) {
 		joinBlockPath := path.Join(dir, "bad-cluster-join-6.block")
-		blockBytes := httputils.MarshalOrPanic(&types.Block{
+		blockBytes := utils.MarshalOrPanic(&types.Block{
 			Header: &types.BlockHeader{
 				BaseHeader: &types.BlockHeaderBase{Number: 10},
 			},
@@ -134,7 +134,7 @@ func TestJoinBlock(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		joinBlockPath := path.Join(dir, "cluster-join.block")
-		blockBytes := httputils.MarshalOrPanic(&types.Block{
+		blockBytes := utils.MarshalOrPanic(&types.Block{
 			Header: &types.BlockHeader{
 				BaseHeader: &types.BlockHeaderBase{Number: 10},
 			},

--- a/internal/blockcreator/blockcreator.go
+++ b/internal/blockcreator/blockcreator.go
@@ -5,8 +5,8 @@ package blockcreator
 import (
 	"github.com/hyperledger-labs/orion-server/internal/blockstore"
 	ierrors "github.com/hyperledger-labs/orion-server/internal/errors"
-	"github.com/hyperledger-labs/orion-server/internal/httputils"
 	"github.com/hyperledger-labs/orion-server/internal/queue"
+	"github.com/hyperledger-labs/orion-server/internal/utils"
 	"github.com/hyperledger-labs/orion-server/pkg/logger"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
 )
@@ -141,7 +141,7 @@ func (b *BlockCreator) Start() {
 				// Releasing with an error will reject or redirect all sync TXs in the block via the pending-tx component.
 				// If there is another leader it will redirect, else reject. Async TXs will be removed.
 				// This will drain the pipeline and eventually there will be no more transactions coming in.
-				if txIDs, errID := httputils.BlockPayloadToTxIDs(block.Payload); errID == nil {
+				if txIDs, errID := utils.BlockPayloadToTxIDs(block.Payload); errID == nil {
 					b.pendingTxs.ReleaseWithError(txIDs, err)
 				} else {
 					b.logger.Errorf("failed to extract TXIDs from block: %s", errID)

--- a/internal/blockstore/commit_and_query.go
+++ b/internal/blockstore/commit_and_query.go
@@ -10,12 +10,11 @@ import (
 	"os"
 	"sync"
 
-	"github.com/hyperledger-labs/orion-server/internal/httputils"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/snappy"
 	interrors "github.com/hyperledger-labs/orion-server/internal/errors"
 	"github.com/hyperledger-labs/orion-server/internal/fileops"
+	"github.com/hyperledger-labs/orion-server/internal/utils"
 	"github.com/hyperledger-labs/orion-server/pkg/crypto"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
 	"github.com/pkg/errors"
@@ -271,7 +270,7 @@ func (s *Store) storeBlockHeaders(block *types.Block) error {
 		return errors.Wrapf(err, "can't calculate block hash {%d, %v}", number, header)
 	}
 
-	txsID, err := httputils.BlockPayloadToTxIDs(block.GetPayload())
+	txsID, err := utils.BlockPayloadToTxIDs(block.GetPayload())
 	blockTxsID := &BlockTxIDs{TxIds: txsID}
 	if err != nil {
 		return errors.Wrapf(err, "can't access block tx ids {%d, %v}", number, block)

--- a/internal/comm/catchup_client.go
+++ b/internal/comm/catchup_client.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/hyperledger-labs/orion-server/internal/httputils"
+	"github.com/hyperledger-labs/orion-server/internal/utils"
 	"github.com/hyperledger-labs/orion-server/pkg/logger"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ type catchUpClient struct {
 func NewCatchUpClient(lg *logger.SugarLogger, tlsConfig *tls.Config) *catchUpClient {
 	c := &catchUpClient{
 		httpClient: newHTTPClient(tlsConfig),
-		tlsConfig: tlsConfig,
+		tlsConfig:  tlsConfig,
 		logger:     lg,
 		members:    make(map[uint64]*url.URL),
 	}
@@ -169,7 +169,7 @@ func (c *catchUpClient) GetBlocks(ctx context.Context, targetID, start, end uint
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("Accept", httputils.MultiPartFormData)
+	req.Header.Add("Accept", utils.MultiPartFormData)
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -247,12 +247,12 @@ func multipartResponseToBlocks(lg *logger.SugarLogger, resp *http.Response) ([]*
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse Content-Type header")
 	}
-	if mediaType != httputils.MultiPartFormData {
-		return nil, errors.Errorf("unexpected Content-Type: [%s], expected %s", mediaType, httputils.MultiPartFormData)
+	if mediaType != utils.MultiPartFormData {
+		return nil, errors.Errorf("unexpected Content-Type: [%s], expected %s", mediaType, utils.MultiPartFormData)
 	}
 	boundary, ok := params["boundary"]
 	if !ok {
-		return nil, errors.Errorf("%s boundary not found", httputils.MultiPartFormData)
+		return nil, errors.Errorf("%s boundary not found", utils.MultiPartFormData)
 	}
 
 	mr := multipart.NewReader(resp.Body, boundary)
@@ -275,7 +275,7 @@ func multipartResponseToBlocks(lg *logger.SugarLogger, resp *http.Response) ([]*
 
 	lg.Debugf("num blocks: %d, total-bytes: %d", len(blocks), totalBytes)
 	if len(blocks) == 0 {
-		return nil, errors.Errorf("empty %s, no blocks found", httputils.MultiPartFormData)
+		return nil, errors.Errorf("empty %s, no blocks found", utils.MultiPartFormData)
 	}
 
 	return blocks, nil

--- a/internal/comm/catchup_handler_test.go
+++ b/internal/comm/catchup_handler_test.go
@@ -14,12 +14,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger-labs/orion-server/internal/comm"
 	"github.com/hyperledger-labs/orion-server/internal/comm/mocks"
-	"github.com/hyperledger-labs/orion-server/internal/httputils"
+	"github.com/hyperledger-labs/orion-server/internal/utils"
 	"github.com/hyperledger-labs/orion-server/pkg/logger"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
-	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -126,7 +126,7 @@ func TestCatchupHandler_ServeHTTP_Blocks(t *testing.T) {
 		q.Add("start", "0")
 		q.Add("end", "4")
 		req.URL.RawQuery = q.Encode()
-		req.Header.Set("Accept", httputils.MultiPartFormData)
+		req.Header.Set("Accept", utils.MultiPartFormData)
 		t.Logf("url: %s", req.URL.String())
 
 		h.ServeHTTP(resp, req)
@@ -145,7 +145,7 @@ func TestCatchupHandler_ServeHTTP_Blocks(t *testing.T) {
 		q.Add("start", "10")
 		q.Add("end", "14")
 		req.URL.RawQuery = q.Encode()
-		req.Header.Set("Accept", httputils.MultiPartFormData)
+		req.Header.Set("Accept", utils.MultiPartFormData)
 		t.Logf("url: %s", req.URL.String())
 
 		h.ServeHTTP(resp, req)
@@ -164,7 +164,7 @@ func TestCatchupHandler_ServeHTTP_Blocks(t *testing.T) {
 		q.Add("start", "4")
 		q.Add("end", "2")
 		req.URL.RawQuery = q.Encode()
-		req.Header.Set("Accept", httputils.MultiPartFormData)
+		req.Header.Set("Accept", utils.MultiPartFormData)
 		t.Logf("url: %s", req.URL.String())
 
 		h.ServeHTTP(resp, req)
@@ -183,7 +183,7 @@ func TestCatchupHandler_ServeHTTP_Blocks(t *testing.T) {
 		q.Add("start", "2")
 		q.Add("end", "4")
 		req.URL.RawQuery = q.Encode()
-		req.Header.Set("Accept", httputils.MultiPartFormData)
+		req.Header.Set("Accept", utils.MultiPartFormData)
 		t.Logf("url: %s", req.URL.String())
 
 		h.ServeHTTP(resp, req)
@@ -219,7 +219,7 @@ func TestCatchupHandler_ServeHTTP_Blocks(t *testing.T) {
 		q.Add("start", "2")
 		q.Add("end", "10")
 		req.URL.RawQuery = q.Encode()
-		req.Header.Set("Accept", httputils.MultiPartFormData)
+		req.Header.Set("Accept", utils.MultiPartFormData)
 		t.Logf("url: %s", req.URL.String())
 
 		h.ServeHTTP(resp, req)
@@ -272,10 +272,10 @@ func TestCatchupHandler_ServeHTTP_LargeResponse(t *testing.T) {
 		ledger1.Append(block)
 
 		if n == 1 {
-			b1Size = len(httputils.MarshalOrPanic(block))
+			b1Size = len(utils.MarshalOrPanic(block))
 		}
 		if n < 6 {
-			b5Size += len(httputils.MarshalOrPanic(block))
+			b5Size += len(utils.MarshalOrPanic(block))
 		}
 	}
 
@@ -289,7 +289,7 @@ func TestCatchupHandler_ServeHTTP_LargeResponse(t *testing.T) {
 		q.Add("start", "2")
 		q.Add("end", "9") // too many
 		req.URL.RawQuery = q.Encode()
-		req.Header.Set("Accept", httputils.MultiPartFormData)
+		req.Header.Set("Accept", utils.MultiPartFormData)
 
 		h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusOK, resp.Result().StatusCode)
@@ -330,7 +330,7 @@ func TestCatchupHandler_ServeHTTP_LargeResponse(t *testing.T) {
 		q.Add("start", "2")
 		q.Add("end", "8") // too many
 		req.URL.RawQuery = q.Encode()
-		req.Header.Set("Accept", httputils.MultiPartFormData)
+		req.Header.Set("Accept", utils.MultiPartFormData)
 
 		h.ServeHTTP(resp, req)
 		require.Equal(t, http.StatusOK, resp.Result().StatusCode)

--- a/internal/httphandler/config_request_handler.go
+++ b/internal/httphandler/config_request_handler.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/hyperledger-labs/orion-server/internal/bcdb"
 	ierrors "github.com/hyperledger-labs/orion-server/internal/errors"
-	"github.com/hyperledger-labs/orion-server/internal/httputils"
+	"github.com/hyperledger-labs/orion-server/internal/utils"
 	"github.com/hyperledger-labs/orion-server/pkg/constants"
 	"github.com/hyperledger-labs/orion-server/pkg/cryptoservice"
 	"github.com/hyperledger-labs/orion-server/pkg/logger"
@@ -63,14 +63,14 @@ func (c *configRequestHandler) configQuery(response http.ResponseWriter, request
 
 	config, err := c.db.GetConfig()
 	if err != nil {
-		httputils.SendHTTPResponse(
+		utils.SendHTTPResponse(
 			response,
 			http.StatusInternalServerError,
 			&types.HttpResponseErr{ErrMsg: "error while processing '" + request.Method + " " + request.URL.String() + "' because " + err.Error()},
 		)
 		return
 	}
-	httputils.SendHTTPResponse(response, http.StatusOK, config)
+	utils.SendHTTPResponse(response, http.StatusOK, config)
 }
 
 func (c *configRequestHandler) configBlockQuery(response http.ResponseWriter, request *http.Request) {
@@ -95,7 +95,7 @@ func (c *configRequestHandler) configBlockQuery(response http.ResponseWriter, re
 			status = http.StatusInternalServerError
 		}
 
-		httputils.SendHTTPResponse(
+		utils.SendHTTPResponse(
 			response,
 			status,
 			&types.HttpResponseErr{
@@ -104,7 +104,7 @@ func (c *configRequestHandler) configBlockQuery(response http.ResponseWriter, re
 		return
 	}
 
-	httputils.SendHTTPResponse(response, http.StatusOK, configBlockResponseEnvelope)
+	utils.SendHTTPResponse(response, http.StatusOK, configBlockResponseEnvelope)
 }
 
 func (c *configRequestHandler) clusterStatusQuery(response http.ResponseWriter, request *http.Request) {
@@ -117,7 +117,7 @@ func (c *configRequestHandler) clusterStatusQuery(response http.ResponseWriter, 
 	clusterStatus, err := c.db.GetClusterStatus(query.NoCertificates)
 
 	if err != nil {
-		httputils.SendHTTPResponse(
+		utils.SendHTTPResponse(
 			response,
 			http.StatusInternalServerError,
 			&types.HttpResponseErr{ErrMsg: "error while processing '" + request.Method + " " + request.URL.String() + "' because " + err.Error()},
@@ -125,7 +125,7 @@ func (c *configRequestHandler) clusterStatusQuery(response http.ResponseWriter, 
 		return
 	}
 
-	httputils.SendHTTPResponse(response, http.StatusOK, clusterStatus)
+	utils.SendHTTPResponse(response, http.StatusOK, clusterStatus)
 }
 
 func (c *configRequestHandler) nodeQuery(response http.ResponseWriter, request *http.Request) {
@@ -138,7 +138,7 @@ func (c *configRequestHandler) nodeQuery(response http.ResponseWriter, request *
 	config, err := c.db.GetNodeConfig(query.NodeId)
 
 	if err != nil {
-		httputils.SendHTTPResponse(
+		utils.SendHTTPResponse(
 			response,
 			http.StatusInternalServerError,
 			&types.HttpResponseErr{ErrMsg: "error while processing '" + request.Method + " " + request.URL.String() + "' because " + err.Error()},
@@ -146,13 +146,13 @@ func (c *configRequestHandler) nodeQuery(response http.ResponseWriter, request *
 		return
 	}
 
-	httputils.SendHTTPResponse(response, http.StatusOK, config)
+	utils.SendHTTPResponse(response, http.StatusOK, config)
 }
 
 func (c *configRequestHandler) configTransaction(response http.ResponseWriter, request *http.Request) {
 	timeout, err := validateAndParseTxPostHeader(&request.Header)
 	if err != nil {
-		httputils.SendHTTPResponse(response, http.StatusBadRequest, &types.HttpResponseErr{ErrMsg: err.Error()})
+		utils.SendHTTPResponse(response, http.StatusBadRequest, &types.HttpResponseErr{ErrMsg: err.Error()})
 		return
 	}
 
@@ -161,30 +161,30 @@ func (c *configRequestHandler) configTransaction(response http.ResponseWriter, r
 
 	txEnv := &types.ConfigTxEnvelope{}
 	if err := d.Decode(txEnv); err != nil {
-		httputils.SendHTTPResponse(response, http.StatusBadRequest, &types.HttpResponseErr{ErrMsg: err.Error()})
+		utils.SendHTTPResponse(response, http.StatusBadRequest, &types.HttpResponseErr{ErrMsg: err.Error()})
 		return
 	}
 
 	if txEnv.Payload == nil {
-		httputils.SendHTTPResponse(response, http.StatusBadRequest,
+		utils.SendHTTPResponse(response, http.StatusBadRequest,
 			&types.HttpResponseErr{ErrMsg: fmt.Sprintf("missing transaction envelope payload (%T)", txEnv.Payload)})
 		return
 	}
 
 	if txEnv.Payload.UserId == "" {
-		httputils.SendHTTPResponse(response, http.StatusBadRequest,
+		utils.SendHTTPResponse(response, http.StatusBadRequest,
 			&types.HttpResponseErr{ErrMsg: fmt.Sprintf("missing UserID in transaction envelope payload (%T)", txEnv.Payload)})
 		return
 	}
 
 	if len(txEnv.Signature) == 0 {
-		httputils.SendHTTPResponse(response, http.StatusBadRequest,
+		utils.SendHTTPResponse(response, http.StatusBadRequest,
 			&types.HttpResponseErr{ErrMsg: fmt.Sprintf("missing Signature in transaction envelope payload (%T)", txEnv.Payload)})
 		return
 	}
 
 	if err, code := VerifyRequestSignature(c.sigVerifier, txEnv.Payload.UserId, txEnv.Signature, txEnv.Payload); err != nil {
-		httputils.SendHTTPResponse(response, code, &types.HttpResponseErr{ErrMsg: err.Error()})
+		utils.SendHTTPResponse(response, code, &types.HttpResponseErr{ErrMsg: err.Error()})
 		return
 	}
 

--- a/internal/httphandler/config_request_handler_test.go
+++ b/internal/httphandler/config_request_handler_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hyperledger-labs/orion-server/internal/bcdb"
 	"github.com/hyperledger-labs/orion-server/internal/bcdb/mocks"
 	interrors "github.com/hyperledger-labs/orion-server/internal/errors"
-	"github.com/hyperledger-labs/orion-server/internal/httputils"
+	"github.com/hyperledger-labs/orion-server/internal/utils"
 	"github.com/hyperledger-labs/orion-server/pkg/constants"
 	"github.com/hyperledger-labs/orion-server/pkg/logger"
 	"github.com/hyperledger-labs/orion-server/pkg/server/testutils"
@@ -753,7 +753,7 @@ func TestConfigRequestHandler_GetLastConfigBlock(t *testing.T) {
 					Header: &types.ResponseHeader{
 						NodeId: "testNodeId",
 					},
-					Block: httputils.MarshalOrPanic(
+					Block: utils.MarshalOrPanic(
 						&types.Block{
 							Header: &types.BlockHeader{
 								BaseHeader: &types.BlockHeaderBase{

--- a/internal/httphandler/ledger_request_handler.go
+++ b/internal/httphandler/ledger_request_handler.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/hyperledger-labs/orion-server/internal/bcdb"
 	"github.com/hyperledger-labs/orion-server/internal/errors"
-	"github.com/hyperledger-labs/orion-server/internal/httputils"
+	"github.com/hyperledger-labs/orion-server/internal/utils"
 	"github.com/hyperledger-labs/orion-server/pkg/constants"
 	"github.com/hyperledger-labs/orion-server/pkg/cryptoservice"
 	"github.com/hyperledger-labs/orion-server/pkg/logger"
@@ -96,7 +96,7 @@ func (p *ledgerRequestHandler) blockQuery(response http.ResponseWriter, request 
 			status = http.StatusInternalServerError
 		}
 
-		httputils.SendHTTPResponse(
+		utils.SendHTTPResponse(
 			response,
 			status,
 			&types.HttpResponseErr{
@@ -105,7 +105,7 @@ func (p *ledgerRequestHandler) blockQuery(response http.ResponseWriter, request 
 		return
 	}
 
-	httputils.SendHTTPResponse(response, http.StatusOK, data)
+	utils.SendHTTPResponse(response, http.StatusOK, data)
 }
 
 func (p *ledgerRequestHandler) lastBlockQuery(response http.ResponseWriter, request *http.Request) {
@@ -133,7 +133,7 @@ func (p *ledgerRequestHandler) lastBlockQuery(response http.ResponseWriter, requ
 			status = http.StatusInternalServerError
 		}
 
-		httputils.SendHTTPResponse(
+		utils.SendHTTPResponse(
 			response,
 			status,
 			&types.HttpResponseErr{
@@ -142,7 +142,7 @@ func (p *ledgerRequestHandler) lastBlockQuery(response http.ResponseWriter, requ
 		return
 	}
 
-	httputils.SendHTTPResponse(response, http.StatusOK, data)
+	utils.SendHTTPResponse(response, http.StatusOK, data)
 }
 
 func (p *ledgerRequestHandler) pathQuery(response http.ResponseWriter, request *http.Request) {
@@ -165,7 +165,7 @@ func (p *ledgerRequestHandler) pathQuery(response http.ResponseWriter, request *
 			status = http.StatusInternalServerError
 		}
 
-		httputils.SendHTTPResponse(
+		utils.SendHTTPResponse(
 			response,
 			status,
 			&types.HttpResponseErr{
@@ -174,7 +174,7 @@ func (p *ledgerRequestHandler) pathQuery(response http.ResponseWriter, request *
 		return
 	}
 
-	httputils.SendHTTPResponse(response, http.StatusOK, data)
+	utils.SendHTTPResponse(response, http.StatusOK, data)
 }
 
 func (p *ledgerRequestHandler) txProof(response http.ResponseWriter, request *http.Request) {
@@ -197,7 +197,7 @@ func (p *ledgerRequestHandler) txProof(response http.ResponseWriter, request *ht
 			status = http.StatusInternalServerError
 		}
 
-		httputils.SendHTTPResponse(
+		utils.SendHTTPResponse(
 			response,
 			status,
 			&types.HttpResponseErr{
@@ -206,7 +206,7 @@ func (p *ledgerRequestHandler) txProof(response http.ResponseWriter, request *ht
 		return
 	}
 
-	httputils.SendHTTPResponse(response, http.StatusOK, data)
+	utils.SendHTTPResponse(response, http.StatusOK, data)
 }
 
 func (p *ledgerRequestHandler) dataProof(response http.ResponseWriter, request *http.Request) {
@@ -228,7 +228,7 @@ func (p *ledgerRequestHandler) dataProof(response http.ResponseWriter, request *
 			status = http.StatusInternalServerError
 		}
 
-		httputils.SendHTTPResponse(
+		utils.SendHTTPResponse(
 			response,
 			status,
 			&types.HttpResponseErr{
@@ -237,7 +237,7 @@ func (p *ledgerRequestHandler) dataProof(response http.ResponseWriter, request *
 		return
 	}
 
-	httputils.SendHTTPResponse(response, http.StatusOK, data)
+	utils.SendHTTPResponse(response, http.StatusOK, data)
 }
 
 func (p *ledgerRequestHandler) txReceipt(response http.ResponseWriter, request *http.Request) {
@@ -260,7 +260,7 @@ func (p *ledgerRequestHandler) txReceipt(response http.ResponseWriter, request *
 			status = http.StatusInternalServerError
 		}
 
-		httputils.SendHTTPResponse(
+		utils.SendHTTPResponse(
 			response,
 			status,
 			&types.HttpResponseErr{
@@ -269,26 +269,26 @@ func (p *ledgerRequestHandler) txReceipt(response http.ResponseWriter, request *
 		return
 	}
 
-	httputils.SendHTTPResponse(response, http.StatusOK, data)
+	utils.SendHTTPResponse(response, http.StatusOK, data)
 }
 
 func (p *ledgerRequestHandler) invalidPathQuery(response http.ResponseWriter, request *http.Request) {
 	err := &types.HttpResponseErr{
 		ErrMsg: "query error - bad or missing start/end block number",
 	}
-	httputils.SendHTTPResponse(response, http.StatusBadRequest, err)
+	utils.SendHTTPResponse(response, http.StatusBadRequest, err)
 }
 
 func (p *ledgerRequestHandler) invalidTxProof(response http.ResponseWriter, request *http.Request) {
 	err := &types.HttpResponseErr{
 		ErrMsg: "tx proof query error - bad or missing query parameter",
 	}
-	httputils.SendHTTPResponse(response, http.StatusBadRequest, err)
+	utils.SendHTTPResponse(response, http.StatusBadRequest, err)
 }
 
 func (p *ledgerRequestHandler) invalidDataProof(response http.ResponseWriter, request *http.Request) {
 	err := &types.HttpResponseErr{
 		ErrMsg: "data proof query error - bad or missing query parameter",
 	}
-	httputils.SendHTTPResponse(response, http.StatusBadRequest, err)
+	utils.SendHTTPResponse(response, http.StatusBadRequest, err)
 }

--- a/internal/httphandler/ledger_request_handler_test.go
+++ b/internal/httphandler/ledger_request_handler_test.go
@@ -94,8 +94,8 @@ func TestBlockQuery(t *testing.T) {
 							},
 						},
 						TxIds: []string{
-								"tx1",
-								"tx2",
+							"tx1",
+							"tx2",
 						},
 					},
 				},

--- a/internal/httphandler/provenance_request_handler.go
+++ b/internal/httphandler/provenance_request_handler.go
@@ -5,14 +5,14 @@ package httphandler
 import (
 	"net/http"
 
+	"github.com/gorilla/mux"
 	"github.com/hyperledger-labs/orion-server/internal/bcdb"
-	"github.com/hyperledger-labs/orion-server/internal/httputils"
+	"github.com/hyperledger-labs/orion-server/internal/utils"
 	"github.com/hyperledger-labs/orion-server/internal/worldstate"
 	"github.com/hyperledger-labs/orion-server/pkg/constants"
 	"github.com/hyperledger-labs/orion-server/pkg/cryptoservice"
 	"github.com/hyperledger-labs/orion-server/pkg/logger"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
-	"github.com/gorilla/mux"
 )
 
 // provenanceRequestHandler handles query and transaction associated
@@ -97,7 +97,7 @@ func (p *provenanceRequestHandler) getHistoricalData(w http.ResponseWriter, r *h
 	case query.Direction == "next":
 		response, err = p.db.GetNextValues(query.DbName, query.Key, query.Version)
 	default:
-		httputils.SendHTTPResponse(w, http.StatusBadRequest, &types.HttpResponseErr{
+		utils.SendHTTPResponse(w, http.StatusBadRequest, &types.HttpResponseErr{
 			ErrMsg: "direction must be either [previous] or [next]",
 		})
 	}
@@ -107,7 +107,7 @@ func (p *provenanceRequestHandler) getHistoricalData(w http.ResponseWriter, r *h
 		return
 	}
 
-	httputils.SendHTTPResponse(w, http.StatusOK, response)
+	utils.SendHTTPResponse(w, http.StatusOK, response)
 }
 
 func (p *provenanceRequestHandler) getDataReaders(w http.ResponseWriter, r *http.Request) {
@@ -123,7 +123,7 @@ func (p *provenanceRequestHandler) getDataReaders(w http.ResponseWriter, r *http
 		return
 	}
 
-	httputils.SendHTTPResponse(w, http.StatusOK, response)
+	utils.SendHTTPResponse(w, http.StatusOK, response)
 }
 
 func (p *provenanceRequestHandler) getDataWriters(w http.ResponseWriter, r *http.Request) {
@@ -139,7 +139,7 @@ func (p *provenanceRequestHandler) getDataWriters(w http.ResponseWriter, r *http
 		return
 	}
 
-	httputils.SendHTTPResponse(w, http.StatusOK, response)
+	utils.SendHTTPResponse(w, http.StatusOK, response)
 }
 
 func (p *provenanceRequestHandler) getDataReadByUser(w http.ResponseWriter, r *http.Request) {
@@ -155,7 +155,7 @@ func (p *provenanceRequestHandler) getDataReadByUser(w http.ResponseWriter, r *h
 		return
 	}
 
-	httputils.SendHTTPResponse(w, http.StatusOK, response)
+	utils.SendHTTPResponse(w, http.StatusOK, response)
 }
 
 func (p *provenanceRequestHandler) getDataWrittenByUser(w http.ResponseWriter, r *http.Request) {
@@ -171,7 +171,7 @@ func (p *provenanceRequestHandler) getDataWrittenByUser(w http.ResponseWriter, r
 		return
 	}
 
-	httputils.SendHTTPResponse(w, http.StatusOK, response)
+	utils.SendHTTPResponse(w, http.StatusOK, response)
 }
 
 func (p *provenanceRequestHandler) getDataDeletedByUser(w http.ResponseWriter, r *http.Request) {
@@ -187,7 +187,7 @@ func (p *provenanceRequestHandler) getDataDeletedByUser(w http.ResponseWriter, r
 		return
 	}
 
-	httputils.SendHTTPResponse(w, http.StatusOK, response)
+	utils.SendHTTPResponse(w, http.StatusOK, response)
 }
 
 func (p *provenanceRequestHandler) getTxIDsSubmittedBy(w http.ResponseWriter, r *http.Request) {
@@ -203,11 +203,11 @@ func (p *provenanceRequestHandler) getTxIDsSubmittedBy(w http.ResponseWriter, r 
 		return
 	}
 
-	httputils.SendHTTPResponse(w, http.StatusOK, response)
+	utils.SendHTTPResponse(w, http.StatusOK, response)
 }
 
 func processInternalError(w http.ResponseWriter, r *http.Request, err error) {
-	httputils.SendHTTPResponse(
+	utils.SendHTTPResponse(
 		w,
 		http.StatusInternalServerError,
 		&types.HttpResponseErr{
@@ -236,5 +236,5 @@ func (p *provenanceRequestHandler) getMostRecentUserOrNode(w http.ResponseWriter
 		return
 	}
 
-	httputils.SendHTTPResponse(w, http.StatusOK, response)
+	utils.SendHTTPResponse(w, http.StatusOK, response)
 }

--- a/internal/httphandler/tx_handler.go
+++ b/internal/httphandler/tx_handler.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hyperledger-labs/orion-server/internal/bcdb"
 	internalerror "github.com/hyperledger-labs/orion-server/internal/errors"
-	"github.com/hyperledger-labs/orion-server/internal/httputils"
+	"github.com/hyperledger-labs/orion-server/internal/utils"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
 )
 
@@ -24,22 +24,22 @@ func (t *txHandler) handleTransaction(w http.ResponseWriter, request *http.Reque
 	if err != nil {
 		switch err.(type) {
 		case *internalerror.BadRequestError:
-			httputils.SendHTTPResponse(w, http.StatusBadRequest, &types.HttpResponseErr{ErrMsg: err.Error()})
+			utils.SendHTTPResponse(w, http.StatusBadRequest, &types.HttpResponseErr{ErrMsg: err.Error()})
 		case *internalerror.DuplicateTxIDError:
-			httputils.SendHTTPResponse(w, http.StatusBadRequest, &types.HttpResponseErr{ErrMsg: err.Error()})
+			utils.SendHTTPResponse(w, http.StatusBadRequest, &types.HttpResponseErr{ErrMsg: err.Error()})
 		case *internalerror.TimeoutErr:
-			httputils.SendHTTPResponse(w, http.StatusAccepted, &types.HttpResponseErr{ErrMsg: "Transaction processing timeout"})
+			utils.SendHTTPResponse(w, http.StatusAccepted, &types.HttpResponseErr{ErrMsg: "Transaction processing timeout"})
 		case *internalerror.NotLeaderError:
 			leaderErr := err.(*internalerror.NotLeaderError)
 			if leaderErr.GetLeaderID() == 0 {
-				httputils.SendHTTPResponse(w, http.StatusServiceUnavailable, &types.HttpResponseErr{ErrMsg: "Cluster leader unavailable"})
+				utils.SendHTTPResponse(w, http.StatusServiceUnavailable, &types.HttpResponseErr{ErrMsg: "Cluster leader unavailable"})
 			} else {
-				httputils.SendHTTPRedirectServer(w, request, leaderErr.GetLeaderHostPort())
+				utils.SendHTTPRedirectServer(w, request, leaderErr.GetLeaderHostPort())
 			}
 		default:
-			httputils.SendHTTPResponse(w, http.StatusInternalServerError, &types.HttpResponseErr{ErrMsg: err.Error()})
+			utils.SendHTTPResponse(w, http.StatusInternalServerError, &types.HttpResponseErr{ErrMsg: err.Error()})
 		}
 		return
 	}
-	httputils.SendHTTPResponse(w, http.StatusOK, resp)
+	utils.SendHTTPResponse(w, http.StatusOK, resp)
 }

--- a/internal/httphandler/utils.go
+++ b/internal/httphandler/utils.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/hyperledger-labs/orion-server/internal/httputils"
+	"github.com/hyperledger-labs/orion-server/internal/utils"
 	"github.com/hyperledger-labs/orion-server/pkg/constants"
 	"github.com/hyperledger-labs/orion-server/pkg/cryptoservice"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
@@ -22,7 +22,7 @@ import (
 func extractVerifiedQueryPayload(w http.ResponseWriter, r *http.Request, queryType string, signVerifier *cryptoservice.SignatureVerifier) (interface{}, bool) {
 	querierUserID, signature, err := validateAndParseHeader(&r.Header)
 	if err != nil {
-		httputils.SendHTTPResponse(w, http.StatusBadRequest, &types.HttpResponseErr{ErrMsg: err.Error()})
+		utils.SendHTTPResponse(w, http.StatusBadRequest, &types.HttpResponseErr{ErrMsg: err.Error()})
 		return nil, true
 	}
 
@@ -57,15 +57,15 @@ func extractVerifiedQueryPayload(w http.ResponseWriter, r *http.Request, queryTy
 		}
 	case constants.GetLastConfigBlock:
 		payload = &types.GetConfigBlockQuery{
-			UserId:               querierUserID,
-			BlockNumber:          0, // 0 means get last, as first block is 1
+			UserId:      querierUserID,
+			BlockNumber: 0, // 0 means get last, as first block is 1
 		}
 	case constants.GetClusterStatus:
 		noCertificates := false
 		if value, ok := params["noCertificates"]; ok {
 			noCertificates, err = strconv.ParseBool(value)
 			if err != nil {
-				httputils.SendHTTPResponse(w, http.StatusBadRequest, err)
+				utils.SendHTTPResponse(w, http.StatusBadRequest, err)
 				return nil, true
 			}
 		}
@@ -75,9 +75,9 @@ func extractVerifiedQueryPayload(w http.ResponseWriter, r *http.Request, queryTy
 			NoCertificates: noCertificates,
 		}
 	case constants.GetBlockHeader:
-		blockNum, err := httputils.GetBlockNum(params)
+		blockNum, err := utils.GetBlockNum(params)
 		if err != nil {
-			httputils.SendHTTPResponse(w, http.StatusBadRequest, err)
+			utils.SendHTTPResponse(w, http.StatusBadRequest, err)
 			return nil, true
 		}
 
@@ -85,7 +85,7 @@ func extractVerifiedQueryPayload(w http.ResponseWriter, r *http.Request, queryTy
 		if _, ok := params["isAugmented"]; ok {
 			augmented, err = strconv.ParseBool(params["isAugmented"])
 			if err != nil {
-				httputils.SendHTTPResponse(w, http.StatusBadRequest, err)
+				utils.SendHTTPResponse(w, http.StatusBadRequest, err)
 				return nil, true
 			}
 		}
@@ -100,9 +100,9 @@ func extractVerifiedQueryPayload(w http.ResponseWriter, r *http.Request, queryTy
 			UserId: querierUserID,
 		}
 	case constants.GetPath:
-		startBlockNum, endBlockNum, err := httputils.GetStartAndEndBlockNum(params)
+		startBlockNum, endBlockNum, err := utils.GetStartAndEndBlockNum(params)
 		if err != nil {
-			httputils.SendHTTPResponse(w, http.StatusBadRequest, err)
+			utils.SendHTTPResponse(w, http.StatusBadRequest, err)
 			return nil, true
 		}
 
@@ -112,9 +112,9 @@ func extractVerifiedQueryPayload(w http.ResponseWriter, r *http.Request, queryTy
 			EndBlockNumber:   endBlockNum,
 		}
 	case constants.GetTxProof:
-		blockNum, txIndex, err := httputils.GetBlockNumAndTxIndex(params)
+		blockNum, txIndex, err := utils.GetBlockNumAndTxIndex(params)
 		if err != nil {
-			httputils.SendHTTPResponse(w, http.StatusBadRequest, err)
+			utils.SendHTTPResponse(w, http.StatusBadRequest, err)
 			return nil, true
 		}
 
@@ -124,9 +124,9 @@ func extractVerifiedQueryPayload(w http.ResponseWriter, r *http.Request, queryTy
 			TxIndex:     txIndex,
 		}
 	case constants.GetDataProof:
-		blockNum, err := httputils.GetBlockNum(params)
+		blockNum, err := utils.GetBlockNum(params)
 		if err != nil {
-			httputils.SendHTTPResponse(w, http.StatusBadRequest, err)
+			utils.SendHTTPResponse(w, http.StatusBadRequest, err)
 			return nil, true
 		}
 
@@ -134,7 +134,7 @@ func extractVerifiedQueryPayload(w http.ResponseWriter, r *http.Request, queryTy
 		if _, ok := params["deleted"]; ok {
 			deleted, err = strconv.ParseBool(params["deleted"])
 			if err != nil {
-				httputils.SendHTTPResponse(w, http.StatusBadRequest, err)
+				utils.SendHTTPResponse(w, http.StatusBadRequest, err)
 				return nil, true
 			}
 		}
@@ -152,15 +152,15 @@ func extractVerifiedQueryPayload(w http.ResponseWriter, r *http.Request, queryTy
 			TxId:   params["txId"],
 		}
 	case constants.GetHistoricalData:
-		version, err := httputils.GetVersion(params)
+		version, err := utils.GetVersion(params)
 		if err != nil {
-			httputils.SendHTTPResponse(w, http.StatusBadRequest, err)
+			utils.SendHTTPResponse(w, http.StatusBadRequest, err)
 			return nil, true
 		}
 
 		v, isOnlyDeletesSet := params["onlydeletes"]
 		if isOnlyDeletesSet && v != "true" {
-			httputils.SendHTTPResponse(w, http.StatusBadRequest, &types.HttpResponseErr{
+			utils.SendHTTPResponse(w, http.StatusBadRequest, &types.HttpResponseErr{
 				ErrMsg: "the onlydeletes parameters must be set only to 'true'",
 			})
 			return nil, true
@@ -210,9 +210,9 @@ func extractVerifiedQueryPayload(w http.ResponseWriter, r *http.Request, queryTy
 			TargetUserId: params["userId"],
 		}
 	case constants.GetMostRecentUserOrNode:
-		version, err := httputils.GetVersion(params)
+		version, err := utils.GetVersion(params)
 		if err != nil {
-			httputils.SendHTTPResponse(w, http.StatusBadRequest, err)
+			utils.SendHTTPResponse(w, http.StatusBadRequest, err)
 			return nil, true
 		}
 
@@ -231,19 +231,19 @@ func extractVerifiedQueryPayload(w http.ResponseWriter, r *http.Request, queryTy
 		}
 	case constants.PostDataQuery:
 		if r.Body == nil {
-			httputils.SendHTTPResponse(w, http.StatusBadRequest, &types.HttpResponseErr{ErrMsg: "query is empty"})
+			utils.SendHTTPResponse(w, http.StatusBadRequest, &types.HttpResponseErr{ErrMsg: "query is empty"})
 			return nil, true
 		}
 
 		b, err := io.ReadAll(r.Body)
 		if err != nil {
-			httputils.SendHTTPResponse(w, http.StatusBadRequest, err)
+			utils.SendHTTPResponse(w, http.StatusBadRequest, err)
 			return nil, true
 		}
 
 		q, err := strconv.Unquote(string(b))
 		if err != nil {
-			httputils.SendHTTPResponse(w, http.StatusBadRequest, err)
+			utils.SendHTTPResponse(w, http.StatusBadRequest, err)
 			return nil, true
 		}
 		payload = &types.DataJSONQuery{
@@ -255,7 +255,7 @@ func extractVerifiedQueryPayload(w http.ResponseWriter, r *http.Request, queryTy
 
 	err, status := VerifyRequestSignature(signVerifier, querierUserID, signature, payload)
 	if err != nil {
-		httputils.SendHTTPResponse(w, status, err)
+		utils.SendHTTPResponse(w, status, err)
 		return nil, true
 	}
 

--- a/internal/replication/blockreplicator_3node_test.go
+++ b/internal/replication/blockreplicator_3node_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	interrors "github.com/hyperledger-labs/orion-server/internal/errors"
-	"github.com/hyperledger-labs/orion-server/internal/httputils"
+	"github.com/hyperledger-labs/orion-server/internal/utils"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -369,7 +369,7 @@ func TestBlockReplicator_3Node_Catchup(t *testing.T) {
 		Payload: &types.Block_DataTxEnvelopes{},
 	}
 	raftConfig := proto.Clone(raftConfigNoSnapshots).(*types.RaftConfig)
-	raftConfig.SnapshotIntervalSize = uint64(4*len(httputils.MarshalOrPanic(block)) + 1) // snapshot every ~5 blocks
+	raftConfig.SnapshotIntervalSize = uint64(4*len(utils.MarshalOrPanic(block)) + 1) // snapshot every ~5 blocks
 
 	env := createClusterEnv(t, 3, raftConfig, "info")
 	defer os.RemoveAll(env.testDir)

--- a/internal/replication/env_test.go
+++ b/internal/replication/env_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger-labs/orion-server/config"
 	"github.com/hyperledger-labs/orion-server/internal/comm"
-	"github.com/hyperledger-labs/orion-server/internal/httputils"
 	"github.com/hyperledger-labs/orion-server/internal/queue"
 	"github.com/hyperledger-labs/orion-server/internal/replication"
 	"github.com/hyperledger-labs/orion-server/internal/replication/mocks"
+	"github.com/hyperledger-labs/orion-server/internal/utils"
 	"github.com/hyperledger-labs/orion-server/pkg/logger"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
 	"github.com/pkg/errors"
@@ -740,7 +740,7 @@ func testDataBlock(approxDataSize int) (*types.Block, uint64) {
 				},
 			}}},
 	}
-	dataBlockLength := uint64(len(httputils.MarshalOrPanic(block)))
+	dataBlockLength := uint64(len(utils.MarshalOrPanic(block)))
 	return block, dataBlockLength
 }
 

--- a/internal/replication/raft_http_error.go
+++ b/internal/replication/raft_http_error.go
@@ -25,6 +25,6 @@ func (e *RaftHTTPError) WriteTo(w http.ResponseWriter) {
 	}
 
 	_, _ = w.Write(b)
-	
+
 	return
 }

--- a/internal/utils/blocks.go
+++ b/internal/utils/blocks.go
@@ -1,11 +1,12 @@
 // Copyright IBM Corp. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package httputils
-
-//TODO rename package to utils, and utils.go to http.go
+package utils
 
 import (
+	"encoding/json"
+
+	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
 	"github.com/pkg/errors"
 )
@@ -78,4 +79,22 @@ func IsConfigBlock(block *types.Block) bool {
 	default:
 		return false
 	}
+}
+
+func MarshalOrPanic(m proto.Message) []byte {
+	bytes, err := proto.Marshal(m)
+	if err != nil {
+		panic(err)
+	}
+
+	return bytes
+}
+
+func MarshalJsonOrPanic(o interface{}) []byte {
+	bytes, err := json.Marshal(o)
+	if err != nil {
+		panic(err)
+	}
+
+	return bytes
 }

--- a/internal/utils/blocks_test.go
+++ b/internal/utils/blocks_test.go
@@ -1,13 +1,13 @@
 // Copyright IBM Corp. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package httputils_test
+package utils_test
 
 import (
 	"fmt"
 	"testing"
 
-	"github.com/hyperledger-labs/orion-server/internal/httputils"
+	"github.com/hyperledger-labs/orion-server/internal/utils"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
 	"github.com/stretchr/testify/require"
 )
@@ -39,7 +39,7 @@ func TestBlockPayloadToTxIDs_Config(t *testing.T) {
 	}
 
 	for i, p := range []interface{}{userAdmin, dbAdmin, config} {
-		txIDs, err := httputils.BlockPayloadToTxIDs(p)
+		txIDs, err := utils.BlockPayloadToTxIDs(p)
 		require.NoError(t, err)
 		require.Len(t, txIDs, 1)
 		require.Equal(t, fmt.Sprintf("txid:%d", i+1), txIDs[0])
@@ -61,7 +61,7 @@ func TestBlockPayloadToTxIDs_Data(t *testing.T) {
 		},
 	}}
 
-	txIDs, err := httputils.BlockPayloadToTxIDs(dataEnv)
+	txIDs, err := utils.BlockPayloadToTxIDs(dataEnv)
 	require.NoError(t, err)
 	require.Len(t, txIDs, 3)
 	for i, id := range txIDs {
@@ -73,7 +73,7 @@ func TestBlockPayloadToTxIDs_Errors(t *testing.T) {
 	t.Run("user admin", func(t *testing.T) {
 		userAdmin := &types.Block_UserAdministrationTxEnvelope{}
 
-		txIDs, err := httputils.BlockPayloadToTxIDs(userAdmin)
+		txIDs, err := utils.BlockPayloadToTxIDs(userAdmin)
 		require.EqualError(t, err, "empty payload in: &{UserAdministrationTxEnvelope:<nil>}")
 		require.Nil(t, txIDs)
 
@@ -81,7 +81,7 @@ func TestBlockPayloadToTxIDs_Errors(t *testing.T) {
 			UserAdministrationTxEnvelope: &types.UserAdministrationTxEnvelope{},
 		}
 
-		txIDs, err = httputils.BlockPayloadToTxIDs(userAdmin)
+		txIDs, err = utils.BlockPayloadToTxIDs(userAdmin)
 		require.EqualError(t, err, "empty payload in: &{UserAdministrationTxEnvelope:}")
 		require.Nil(t, txIDs)
 
@@ -91,7 +91,7 @@ func TestBlockPayloadToTxIDs_Errors(t *testing.T) {
 			},
 		}
 
-		txIDs, err = httputils.BlockPayloadToTxIDs(userAdmin)
+		txIDs, err = utils.BlockPayloadToTxIDs(userAdmin)
 		require.EqualError(t, err, "missing TxId in: &{UserAdministrationTxEnvelope:payload:<> }")
 		require.Nil(t, txIDs)
 	})
@@ -99,7 +99,7 @@ func TestBlockPayloadToTxIDs_Errors(t *testing.T) {
 	t.Run("db admin", func(t *testing.T) {
 		dbAdmin := &types.Block_DbAdministrationTxEnvelope{}
 
-		txIDs, err := httputils.BlockPayloadToTxIDs(dbAdmin)
+		txIDs, err := utils.BlockPayloadToTxIDs(dbAdmin)
 		require.EqualError(t, err, "empty payload in: &{DbAdministrationTxEnvelope:<nil>}")
 		require.Nil(t, txIDs)
 
@@ -107,7 +107,7 @@ func TestBlockPayloadToTxIDs_Errors(t *testing.T) {
 			DbAdministrationTxEnvelope: &types.DBAdministrationTxEnvelope{},
 		}
 
-		txIDs, err = httputils.BlockPayloadToTxIDs(dbAdmin)
+		txIDs, err = utils.BlockPayloadToTxIDs(dbAdmin)
 		require.EqualError(t, err, "empty payload in: &{DbAdministrationTxEnvelope:}")
 		require.Nil(t, txIDs)
 
@@ -117,7 +117,7 @@ func TestBlockPayloadToTxIDs_Errors(t *testing.T) {
 			},
 		}
 
-		txIDs, err = httputils.BlockPayloadToTxIDs(dbAdmin)
+		txIDs, err = utils.BlockPayloadToTxIDs(dbAdmin)
 		require.EqualError(t, err, "missing TxId in: &{DbAdministrationTxEnvelope:payload:<> }")
 		require.Nil(t, txIDs)
 	})
@@ -125,7 +125,7 @@ func TestBlockPayloadToTxIDs_Errors(t *testing.T) {
 	t.Run("config", func(t *testing.T) {
 		config := &types.Block_ConfigTxEnvelope{}
 
-		txIDs, err := httputils.BlockPayloadToTxIDs(config)
+		txIDs, err := utils.BlockPayloadToTxIDs(config)
 		require.EqualError(t, err, "empty payload in: &{ConfigTxEnvelope:<nil>}")
 		require.Nil(t, txIDs)
 
@@ -133,7 +133,7 @@ func TestBlockPayloadToTxIDs_Errors(t *testing.T) {
 			ConfigTxEnvelope: &types.ConfigTxEnvelope{},
 		}
 
-		txIDs, err = httputils.BlockPayloadToTxIDs(config)
+		txIDs, err = utils.BlockPayloadToTxIDs(config)
 		require.EqualError(t, err, "empty payload in: &{ConfigTxEnvelope:}")
 		require.Nil(t, txIDs)
 
@@ -143,7 +143,7 @@ func TestBlockPayloadToTxIDs_Errors(t *testing.T) {
 			},
 		}
 
-		txIDs, err = httputils.BlockPayloadToTxIDs(config)
+		txIDs, err = utils.BlockPayloadToTxIDs(config)
 		require.EqualError(t, err, "missing TxId in: &{ConfigTxEnvelope:payload:<> }")
 		require.Nil(t, txIDs)
 	})
@@ -151,7 +151,7 @@ func TestBlockPayloadToTxIDs_Errors(t *testing.T) {
 	t.Run("data", func(t *testing.T) {
 		data := &types.Block_DataTxEnvelopes{}
 
-		txIDs, err := httputils.BlockPayloadToTxIDs(data)
+		txIDs, err := utils.BlockPayloadToTxIDs(data)
 		require.EqualError(t, err, "empty payload in: &{DataTxEnvelopes:<nil>}")
 		require.Nil(t, txIDs)
 
@@ -159,7 +159,7 @@ func TestBlockPayloadToTxIDs_Errors(t *testing.T) {
 			DataTxEnvelopes: &types.DataTxEnvelopes{},
 		}
 
-		txIDs, err = httputils.BlockPayloadToTxIDs(data)
+		txIDs, err = utils.BlockPayloadToTxIDs(data)
 		require.EqualError(t, err, "empty payload in: &{DataTxEnvelopes:}")
 		require.Nil(t, txIDs)
 
@@ -168,7 +168,7 @@ func TestBlockPayloadToTxIDs_Errors(t *testing.T) {
 				Envelopes: []*types.DataTxEnvelope{},
 			},
 		}
-		txIDs, err = httputils.BlockPayloadToTxIDs(data)
+		txIDs, err = utils.BlockPayloadToTxIDs(data)
 		require.EqualError(t, err, "empty payload in: &{DataTxEnvelopes:}")
 		require.Nil(t, txIDs)
 
@@ -181,7 +181,7 @@ func TestBlockPayloadToTxIDs_Errors(t *testing.T) {
 				},
 			},
 		}
-		txIDs, err = httputils.BlockPayloadToTxIDs(data)
+		txIDs, err = utils.BlockPayloadToTxIDs(data)
 		require.EqualError(t, err, "empty payload in index [0]: &{DataTxEnvelopes:envelopes:<> }")
 		require.Nil(t, txIDs)
 
@@ -202,7 +202,7 @@ func TestBlockPayloadToTxIDs_Errors(t *testing.T) {
 				},
 			},
 		}
-		txIDs, err = httputils.BlockPayloadToTxIDs(data)
+		txIDs, err = utils.BlockPayloadToTxIDs(data)
 		require.EqualError(t, err, "missing TxId in index [1]: &{DataTxEnvelopes:envelopes:<payload:<must_sign_user_ids:\"alice\" tx_id:\"txid:1\" > > envelopes:<payload:<must_sign_user_ids:\"bob\" > > }")
 		require.Nil(t, txIDs)
 	})
@@ -250,7 +250,7 @@ func TestIsConfigBlock(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			isConfig := httputils.IsConfigBlock(tc.block)
+			isConfig := utils.IsConfigBlock(tc.block)
 			require.Equal(t, tc.expected, isConfig)
 		})
 	}

--- a/internal/utils/http.go
+++ b/internal/utils/http.go
@@ -1,7 +1,7 @@
 // Copyright IBM Corp. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package httputils
+package utils
 
 import (
 	"encoding/json"
@@ -11,29 +11,10 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
 )
 
 const MultiPartFormData = "multipart/form-data"
-
-func MarshalOrPanic(m proto.Message) []byte {
-	bytes, err := proto.Marshal(m)
-	if err != nil {
-		panic(err)
-	}
-
-	return bytes
-}
-
-func MarshalJsonOrPanic(o interface{}) []byte {
-	bytes, err := json.Marshal(o)
-	if err != nil {
-		panic(err)
-	}
-
-	return bytes
-}
 
 // SendHTTPResponse writes HTTP response back including HTTP code number and encode payload
 func SendHTTPResponse(w http.ResponseWriter, code int, payload interface{}) {

--- a/internal/utils/http_test.go
+++ b/internal/utils/http_test.go
@@ -1,6 +1,6 @@
 // Copyright IBM Corp. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-package httputils
+package utils
 
 import (
 	"bytes"

--- a/test/setup/cluster_setup_test.go
+++ b/test/setup/cluster_setup_test.go
@@ -23,8 +23,8 @@ func TestClusterSetup(t *testing.T) {
 		TestDirAbsolutePath: dir,
 		BDBBinaryPath:       "../../bin/bdb",
 		CmdTimeout:          10 * time.Second,
-		BaseNodePort: 64000,
-		BasePeerPort: 64100,
+		BaseNodePort:        64000,
+		BasePeerPort:        64100,
 	}
 	c, err := setup.NewCluster(setupConfig)
 	require.NoError(t, err)

--- a/test/setup/config_writer_test.go
+++ b/test/setup/config_writer_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/hyperledger-labs/orion-server/config"
-	"github.com/hyperledger-labs/orion-server/internal/httputils"
+	"github.com/hyperledger-labs/orion-server/internal/utils"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )
@@ -69,7 +69,7 @@ func TestWriteLocalConfig(t *testing.T) {
 	recoveredConf := &config.LocalConfiguration{}
 	err = v.UnmarshalExact(recoveredConf)
 	require.NoError(t, err)
-	require.Equal(t, httputils.MarshalJsonOrPanic(localConfig), httputils.MarshalJsonOrPanic(recoveredConf))
+	require.Equal(t, utils.MarshalJsonOrPanic(localConfig), utils.MarshalJsonOrPanic(recoveredConf))
 }
 
 func TestWriteSharedConfig(t *testing.T) {
@@ -116,5 +116,5 @@ func TestWriteSharedConfig(t *testing.T) {
 	recoveredConf := &config.SharedConfiguration{}
 	err = v.UnmarshalExact(recoveredConf)
 	require.NoError(t, err)
-	require.Equal(t, httputils.MarshalJsonOrPanic(sharedConfig), httputils.MarshalJsonOrPanic(recoveredConf))
+	require.Equal(t, utils.MarshalJsonOrPanic(sharedConfig), utils.MarshalJsonOrPanic(recoveredConf))
 }


### PR DESCRIPTION
Rename `httputils` package to `utils`
Rename file `utils.go` to `http.go`

No functional change.