### PR TITLE
Changing docker image with openssl

### DIFF
--- a/scripts/cryptoGen.sh
+++ b/scripts/cryptoGen.sh
@@ -5,13 +5,14 @@ create_pki() {
         mkdir -p "$BASE_DIR/crypto/$1"
 
         echo "Generating private key for $1"
-        docker run -it --rm -v $BASE_DIR/crypto:/export frapsoft/openssl ecparam -name prime256v1 -genkey -noout -out "/export/$1/$1.key"
+        docker run -it --rm -v $BASE_DIR/crypto:/export nginx openssl ecparam -name prime256v1 -genkey -noout -out "/export/$1/$1.key"
+        docker run -it --rm -v $BASE_DIR/crypto:/export nginx chmod ga+r "/export/$1/$1.key"
 
         echo "Generate node CSR"
-        docker run -it --rm -v $BASE_DIR/crypto:/export frapsoft/openssl req -new -key "/export/$1/$1.key" -out "/export/$1/$1.csr" -subj "/C=IL/ST=Haifa/O=BCDB"
+        docker run -it --rm -v $BASE_DIR/crypto:/export nginx openssl req -new -key "/export/$1/$1.key" -out "/export/$1/$1.csr" -subj "/C=IL/ST=Haifa/O=BCDB"
 
         echo "Generate node certificate"
-        docker run -it --rm -v $BASE_DIR/crypto:/export frapsoft/openssl x509 -req -in "/export/$1/$1.csr" -CA "/export/CA/CA.pem" -CAkey "/export/CA/CA.key" -CAcreateserial -out "/export/$1/$1.pem" -days 365 -sha256
+        docker run -it --rm -v $BASE_DIR/crypto:/export nginx openssl x509 -req -in "/export/$1/$1.csr" -CA "/export/CA/CA.pem" -CAkey "/export/CA/CA.key" -CAcreateserial -out "/export/$1/$1.pem" -days 365 -sha256
 }
 
 if [ -z "$1" ]
@@ -34,10 +35,11 @@ echo "Creating PKIs folders"
 mkdir -p "$BASE_DIR/crypto/CA"
 
 echo "Generate root CA private key"
-docker run -it --rm -v $BASE_DIR/crypto:/export frapsoft/openssl ecparam -name prime256v1 -genkey -noout -out "/export/CA/CA.key"
+docker run -it --rm -v $BASE_DIR/crypto:/export nginx openssl ecparam -name prime256v1 -genkey -noout -out "/export/CA/CA.key"
+docker run -it --rm -v $BASE_DIR/crypto:/export nginx chmod ga+r "/export/CA/CA.key"
 
 echo "Generating self-signed root CA certificate"
-docker run -it --rm -v $BASE_DIR/crypto:/export frapsoft/openssl req -new -x509 -nodes -key "/export/CA/CA.key" -sha256 -days 365 -out "/export/CA/CA.pem" -subj "/C=IL/ST=Haifa/O=BCDB" -extensions v3_ca
+docker run -it --rm -v $BASE_DIR/crypto:/export nginx openssl req -new -x509 -nodes -key "/export/CA/CA.key" -sha256 -days 365 -out "/export/CA/CA.pem" -subj "/C=IL/ST=Haifa/O=BCDB" -extensions v3_ca
 
 for f in "server" "admin" "user"
 do


### PR DESCRIPTION
Because frapsoft/openssl image doesn't have s390x build, we raplaced it with image that for sure has such support - nginx.

Signed-off-by: Gennady Laventman <gennady@il.ibm.com>