### PR TITLE
Server test crypto utilities rename

### DIFF
--- a/config/ca_config_test.go
+++ b/config/ca_config_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestCAConfiguration_WriteBundle(t *testing.T) {
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"user", "node"}, true)
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"user", "node"}, true)
 
 	rootCAFileName := path.Join(cryptoDir, testutils.RootCAFileName+".pem")
 	interCAFileName := path.Join(cryptoDir, testutils.IntermediateCAFileName+".pem")

--- a/internal/bcdb/transaction_processor_test.go
+++ b/internal/bcdb/transaction_processor_test.go
@@ -114,7 +114,7 @@ func newTxProcessorTestEnv(t *testing.T, cryptoDir string, conf *config.Configur
 		t.Fatalf("error while creating state trie store, %v", err)
 	}
 
-	userCert, userSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "testUser")
+	userCert, userSigner := testutils.LoadTestCrypto(t, cryptoDir, "testUser")
 
 	txProcConf := &txProcessorConfig{
 		config:          conf,
@@ -589,7 +589,7 @@ func testConfiguration(t *testing.T) (string, *config.Configurations) {
 	ledgerDir, err := ioutil.TempDir("/tmp", "server")
 	require.NoError(t, err)
 
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"testUser", "bdb-node-1", "admin"})
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"testUser", "bdb-node-1", "admin"})
 
 	return cryptoDir, &config.Configurations{
 		LocalConfig: &config.LocalConfiguration{
@@ -666,7 +666,7 @@ func testJoinConfiguration(t *testing.T) (string, *config.Configurations) {
 	ledgerDir, err := ioutil.TempDir("/tmp", "server")
 	require.NoError(t, err)
 
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"testUser", "bdb-node-1", "bdb-node-2", "admin"})
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"testUser", "bdb-node-1", "bdb-node-2", "admin"})
 
 	clusterConfig := &types.ClusterConfig{
 		Nodes: []*types.NodeConfig{

--- a/internal/blockprocessor/processor_test.go
+++ b/internal/blockprocessor/processor_test.go
@@ -126,11 +126,11 @@ func newTestEnv(t *testing.T) *testEnv {
 		},
 	)
 
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"testUser", "node1", "admin1"})
-	userCert, userSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "testUser")
-	nodeCert, _ := testutils.LoadTestClientCrypto(t, cryptoDir, "node1")
-	adminCert, _ := testutils.LoadTestClientCrypto(t, cryptoDir, "admin1")
-	caCert, _ := testutils.LoadTestClientCA(t, cryptoDir, testutils.RootCAFileName)
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"testUser", "node1", "admin1"})
+	userCert, userSigner := testutils.LoadTestCrypto(t, cryptoDir, "testUser")
+	nodeCert, _ := testutils.LoadTestCrypto(t, cryptoDir, "node1")
+	adminCert, _ := testutils.LoadTestCrypto(t, cryptoDir, "admin1")
+	caCert, _ := testutils.LoadTestCA(t, cryptoDir, testutils.RootCAFileName)
 
 	b := New(&Config{
 		BlockOneQueueBarrier: queue.NewOneQueueBarrier(logger),

--- a/internal/comm/httptransport_test.go
+++ b/internal/comm/httptransport_test.go
@@ -871,7 +871,7 @@ func newTestSetup(t *testing.T, numServers int) ([]*config.LocalConfiguration, *
 	for i := 0; i < numServers; i++ {
 		nodeIDs = append(nodeIDs, fmt.Sprintf("node%d", i+1))
 	}
-	cryptoDir := testutils.GenerateTestClientCrypto(t, nodeIDs, true)
+	cryptoDir := testutils.GenerateTestCrypto(t, nodeIDs, true)
 	auxDir, err := ioutil.TempDir("/tmp", "UnitTestAux")
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/internal/httphandler/config_request_handler_test.go
+++ b/internal/httphandler/config_request_handler_test.go
@@ -39,9 +39,9 @@ func createLogger(logLevel string) (*logger.SugarLogger, error) {
 
 func TestConfigRequestHandler_GetConfig(t *testing.T) {
 	submittingUserName := "alice"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice", "bob"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
-	_, bobSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "bob")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice", "bob"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
+	_, bobSigner := testutils.LoadTestCrypto(t, cryptoDir, "bob")
 
 	testCases := []struct {
 		name               string
@@ -216,8 +216,8 @@ func TestConfigRequestHandler_GetConfig(t *testing.T) {
 
 func TestConfigRequestHandler_SubmitConfig(t *testing.T) {
 	submittingUserName := "admin"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"admin"})
-	adminCert, adminSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "admin")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"admin"})
+	adminCert, adminSigner := testutils.LoadTestCrypto(t, cryptoDir, "admin")
 
 	configTx := &types.ConfigTx{
 		UserId: submittingUserName,
@@ -546,9 +546,9 @@ func TestConfigRequestHandler_SubmitConfig(t *testing.T) {
 
 func TestConfigRequestHandler_GetNodesConfig(t *testing.T) {
 	submittingUserName := "alice"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice", "bob"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
-	_, bobSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "bob")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice", "bob"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
+	_, bobSigner := testutils.LoadTestCrypto(t, cryptoDir, "bob")
 
 	testCases := []struct {
 		name               string
@@ -721,9 +721,9 @@ func TestConfigRequestHandler_GetNodesConfig(t *testing.T) {
 
 func TestConfigRequestHandler_GetLastConfigBlock(t *testing.T) {
 	submittingUserName := "alice"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice", "bob"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
-	_, bobSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "bob")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice", "bob"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
+	_, bobSigner := testutils.LoadTestCrypto(t, cryptoDir, "bob")
 
 	testCases := []struct {
 		name               string
@@ -896,9 +896,9 @@ func TestConfigRequestHandler_GetLastConfigBlock(t *testing.T) {
 
 func TestConfigRequestHandler_GetClusterStatus(t *testing.T) {
 	submittingUserName := "alice"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice", "bob"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
-	_, bobSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "bob")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice", "bob"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
+	_, bobSigner := testutils.LoadTestCrypto(t, cryptoDir, "bob")
 
 	testCases := []struct {
 		name               string

--- a/internal/httphandler/data_request_handler_test.go
+++ b/internal/httphandler/data_request_handler_test.go
@@ -28,9 +28,9 @@ func TestDataRequestHandler_DataQuery(t *testing.T) {
 	dbName := "test_database"
 
 	submittingUserName := "alice"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice", "bob"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
-	_, bobSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "bob")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice", "bob"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
+	_, bobSigner := testutils.LoadTestCrypto(t, cryptoDir, "bob")
 
 	sigFoo := testutils.SignatureFromQuery(t, aliceSigner, &types.GetDataQuery{
 		UserId: submittingUserName,
@@ -244,9 +244,9 @@ func TestDataRequestHandler_DataJSONQuery(t *testing.T) {
 	dbName := "test_database"
 
 	submittingUserName := "alice"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice", "bob"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
-	bobCert, _ := testutils.LoadTestClientCrypto(t, cryptoDir, "bob")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice", "bob"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
+	bobCert, _ := testutils.LoadTestCrypto(t, cryptoDir, "bob")
 
 	q := `{"attr1":{"$eq":true}}`
 	queryBytes, err := json.Marshal(q)
@@ -513,10 +513,10 @@ func TestDataRequestHandler_DataTransaction(t *testing.T) {
 	alice := "alice"
 	bob := "bob"
 	charlie := "charlie"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice", "bob", "charlie"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
-	bobCert, bobSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "bob")
-	_, charlieSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "charlie")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice", "bob", "charlie"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
+	bobCert, bobSigner := testutils.LoadTestCrypto(t, cryptoDir, "bob")
+	_, charlieSigner := testutils.LoadTestCrypto(t, cryptoDir, "charlie")
 
 	dataTx := &types.DataTx{
 		MustSignUserIds: []string{alice, bob},
@@ -957,8 +957,8 @@ func TestDataRequestHandler_DataJSONQueryWithContext(t *testing.T) {
 	dbName := "test_database"
 
 	submittingUserName := "alice"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice", "bob"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice", "bob"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
 
 	q := `{"attr1":{"$eq":true}}`
 	queryBytes, err := json.Marshal(q)

--- a/internal/httphandler/db_request_handler_test.go
+++ b/internal/httphandler/db_request_handler_test.go
@@ -27,9 +27,9 @@ func TestDBRequestHandler_DBStatus(t *testing.T) {
 	submittingUserName := "alice"
 	dbName := "testDBName"
 
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice", "bob"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
-	_, bobSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "bob")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice", "bob"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
+	_, bobSigner := testutils.LoadTestCrypto(t, cryptoDir, "bob")
 
 	testCases := []struct {
 		name               string
@@ -216,9 +216,9 @@ func TestDBRequestHandler_DBIndex(t *testing.T) {
 	submittingUserName := "alice"
 	dbName := "testDBName"
 
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice", "bob"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
-	_, bobSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "bob")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice", "bob"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
+	_, bobSigner := testutils.LoadTestCrypto(t, cryptoDir, "bob")
 
 	testCases := []struct {
 		name               string
@@ -420,8 +420,8 @@ func TestDBRequestHandler_DBIndex(t *testing.T) {
 
 func TestDBRequestHandler_DBTransaction(t *testing.T) {
 	userID := "alice"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
 
 	dbTx := &types.DBAdministrationTx{
 		TxId:      "1",

--- a/internal/httphandler/ledger_request_handler_test.go
+++ b/internal/httphandler/ledger_request_handler_test.go
@@ -25,8 +25,8 @@ import (
 
 func TestBlockQuery(t *testing.T) {
 	submittingUserName := "alice"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
 
 	testCases := []struct {
 		name           string
@@ -265,8 +265,8 @@ func TestBlockQuery(t *testing.T) {
 
 func TestPathQuery(t *testing.T) {
 	submittingUserName := "alice"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
 
 	testCases := []struct {
 		name               string
@@ -482,8 +482,8 @@ func TestPathQuery(t *testing.T) {
 
 func TestTxProofQuery(t *testing.T) {
 	submittingUserName := "alice"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
 
 	testCases := []struct {
 		name               string
@@ -687,8 +687,8 @@ func TestTxProofQuery(t *testing.T) {
 
 func TestDataProofQuery(t *testing.T) {
 	submittingUserName := "alice"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
 
 	testCases := []struct {
 		name               string
@@ -986,8 +986,8 @@ func TestDataProofQuery(t *testing.T) {
 
 func TestTxReceiptQuery(t *testing.T) {
 	submittingUserName := "alice"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
 
 	testCases := []struct {
 		name               string

--- a/internal/httphandler/provenance_request_handler_test.go
+++ b/internal/httphandler/provenance_request_handler_test.go
@@ -33,8 +33,8 @@ func TestGetHistoricalData(t *testing.T) {
 	t.Parallel()
 
 	submittingUserName := "alice"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
 
 	dbName := "db1"
 	key := "key1"
@@ -236,8 +236,8 @@ func TestGetDataReaders(t *testing.T) {
 	t.Parallel()
 
 	submittingUserName := "alice"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
 
 	dbName := "db1"
 	key := "key1"
@@ -304,8 +304,8 @@ func TestGetDataWriters(t *testing.T) {
 	t.Parallel()
 
 	submittingUserName := "alice"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
 
 	dbName := "db1"
 	key := "key1"
@@ -372,8 +372,8 @@ func TestGetDataReadBy(t *testing.T) {
 	t.Parallel()
 
 	submittingUserName := "alice"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
 
 	targetUserID := "user1"
 	genericResponse := &types.GetDataProvenanceResponseEnvelope{
@@ -441,8 +441,8 @@ func TestGetDataWrittenBy(t *testing.T) {
 	t.Parallel()
 
 	submittingUserName := "alice"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
 
 	targetUserID := "user1"
 	genericResponse := &types.GetDataProvenanceResponseEnvelope{
@@ -510,8 +510,8 @@ func TestGetDataDeletedBy(t *testing.T) {
 	t.Parallel()
 
 	submittingUserName := "alice"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
 
 	targetUserID := "user1"
 	genericResponse := &types.GetDataProvenanceResponseEnvelope{
@@ -579,8 +579,8 @@ func TestGetTxIDsSubmittedBy(t *testing.T) {
 	t.Parallel()
 
 	submittingUserName := "alice"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
 
 	targetUserID := "user1"
 	genericResponse := &types.GetTxIDsSubmittedByResponseEnvelope{
@@ -643,8 +643,8 @@ func TestGetMostRecentNodeOrUser(t *testing.T) {
 	t.Parallel()
 
 	submittingUserName := "alice"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
 
 	sampleVer := &types.Version{
 		BlockNum: 5,

--- a/internal/httphandler/users_request_handler_test.go
+++ b/internal/httphandler/users_request_handler_test.go
@@ -27,9 +27,9 @@ func TestUsersRequestHandler_GetUser(t *testing.T) {
 	submittingUserName := "alice"
 	targetUserID := "targetUserID"
 
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice", "bob"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
-	_, bobSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "bob")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice", "bob"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
+	_, bobSigner := testutils.LoadTestCrypto(t, cryptoDir, "bob")
 
 	testCases := []struct {
 		name               string
@@ -223,8 +223,8 @@ func TestUsersRequestHandler_SubmitUserTx(t *testing.T) {
 	userGet := "userGet"
 	userWrite := "userWrite"
 
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
 
 	userTx := &types.UserAdministrationTx{
 		TxId:        "1",

--- a/internal/httphandler/utils_test.go
+++ b/internal/httphandler/utils_test.go
@@ -24,8 +24,8 @@ func TestVerifyRequestSignature(t *testing.T) {
 		Name:          "unit-test",
 	})
 	require.NoError(t, err)
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, "alice")
 
 	t.Run("good sig", func(t *testing.T) {
 		db := &mocks.DB{}

--- a/internal/txvalidation/config_tx_validator_test.go
+++ b/internal/txvalidation/config_tx_validator_test.go
@@ -20,11 +20,11 @@ func TestValidateConfigTx(t *testing.T) {
 	t.Parallel()
 
 	userID := "adminUser"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"adminUser", "nonAdminUser", "node"})
-	adminCert, adminSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "adminUser")
-	nonAdminCert, nonAdminSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "nonAdminUser")
-	nodeCert, _ := testutils.LoadTestClientCrypto(t, cryptoDir, "node")
-	caCert, caKey := testutils.LoadTestClientCA(t, cryptoDir, testutils.RootCAFileName)
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"adminUser", "nonAdminUser", "node"})
+	adminCert, adminSigner := testutils.LoadTestCrypto(t, cryptoDir, "adminUser")
+	nonAdminCert, nonAdminSigner := testutils.LoadTestCrypto(t, cryptoDir, "nonAdminUser")
+	nodeCert, _ := testutils.LoadTestCrypto(t, cryptoDir, "node")
+	caCert, caKey := testutils.LoadTestCA(t, cryptoDir, testutils.RootCAFileName)
 	require.NotNil(t, caKey)
 
 	setup := func(db worldstate.DB) {
@@ -601,9 +601,9 @@ func TestValidateConfigTx(t *testing.T) {
 func TestValidateCAConfig(t *testing.T) {
 	t.Parallel()
 
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"node"})
-	nodeCert, _ := testutils.LoadTestClientCrypto(t, cryptoDir, "node")
-	caCert, _ := testutils.LoadTestClientCA(t, cryptoDir, testutils.RootCAFileName)
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"node"})
+	nodeCert, _ := testutils.LoadTestCrypto(t, cryptoDir, "node")
+	caCert, _ := testutils.LoadTestCA(t, cryptoDir, testutils.RootCAFileName)
 
 	//TODO add additional test cases once we implement: https://github.ibm.com/blockchaindb/server/issues/358
 	tests := []struct {
@@ -685,9 +685,9 @@ func TestValidateCAConfig(t *testing.T) {
 func TestValidateNodeConfig(t *testing.T) {
 	t.Parallel()
 
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"node"})
-	nodeCert, _ := testutils.LoadTestClientCrypto(t, cryptoDir, "node")
-	caCert, _ := testutils.LoadTestClientCA(t, cryptoDir, testutils.RootCAFileName)
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"node"})
+	nodeCert, _ := testutils.LoadTestCrypto(t, cryptoDir, "node")
+	caCert, _ := testutils.LoadTestCA(t, cryptoDir, testutils.RootCAFileName)
 	caCertCollection, err := certificateauthority.NewCACertCollection([][]byte{caCert.Raw}, nil)
 	require.NoError(t, err)
 
@@ -839,9 +839,9 @@ func TestValidateNodeConfig(t *testing.T) {
 func TestValidateAdminConfig(t *testing.T) {
 	t.Parallel()
 
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"admin"})
-	adminCert, _ := testutils.LoadTestClientCrypto(t, cryptoDir, "admin")
-	caCert, _ := testutils.LoadTestClientCA(t, cryptoDir, testutils.RootCAFileName)
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"admin"})
+	adminCert, _ := testutils.LoadTestCrypto(t, cryptoDir, "admin")
+	caCert, _ := testutils.LoadTestCA(t, cryptoDir, testutils.RootCAFileName)
 	caCertCollection, err := certificateauthority.NewCACertCollection([][]byte{caCert.Raw}, nil)
 	require.NoError(t, err)
 

--- a/internal/txvalidation/data_tx_validator_test.go
+++ b/internal/txvalidation/data_tx_validator_test.go
@@ -20,10 +20,10 @@ func TestValidateDataTx(t *testing.T) {
 
 	alice := "alice"
 	bob := "bob"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{alice, bob, "bogusUser"})
-	aliceCert, aliceSigner := testutils.LoadTestClientCrypto(t, cryptoDir, alice)
-	bobCert, bobSigner := testutils.LoadTestClientCrypto(t, cryptoDir, bob)
-	bogusCert, _ := testutils.LoadTestClientCrypto(t, cryptoDir, "bogusUser")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{alice, bob, "bogusUser"})
+	aliceCert, aliceSigner := testutils.LoadTestCrypto(t, cryptoDir, alice)
+	bobCert, bobSigner := testutils.LoadTestCrypto(t, cryptoDir, bob)
+	bogusCert, _ := testutils.LoadTestCrypto(t, cryptoDir, "bogusUser")
 
 	addUserWithCorrectPrivilege := func(db worldstate.DB) {
 		a := &types.User{

--- a/internal/txvalidation/dbadmin_tx_validator_test.go
+++ b/internal/txvalidation/dbadmin_tx_validator_test.go
@@ -17,9 +17,9 @@ import (
 func TestValidateDBAdminTx(t *testing.T) {
 	t.Parallel()
 
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"userWithMorePrivilege", "userWithLessPrivilege"})
-	adminCert, adminSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "userWithMorePrivilege")
-	nonAdminCert, nonAdminSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "userWithLessPrivilege")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"userWithMorePrivilege", "userWithLessPrivilege"})
+	adminCert, adminSigner := testutils.LoadTestCrypto(t, cryptoDir, "userWithMorePrivilege")
+	nonAdminCert, nonAdminSigner := testutils.LoadTestCrypto(t, cryptoDir, "userWithLessPrivilege")
 
 	sampleMetadataData := &types.Metadata{
 		Version: &types.Version{

--- a/internal/txvalidation/useradmin_tx_validator_test.go
+++ b/internal/txvalidation/useradmin_tx_validator_test.go
@@ -18,11 +18,11 @@ import (
 func TestValidateUsedAdminTx(t *testing.T) {
 	t.Parallel()
 
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"adminUser", "nonAdminUser", "user1"})
-	adminCert, adminSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "adminUser")
-	nonAdminCert, nonAdminSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "nonAdminUser")
-	user1Cert, _ := testutils.LoadTestClientCrypto(t, cryptoDir, "nonAdminUser")
-	caCert, _ := testutils.LoadTestClientCA(t, cryptoDir, testutils.RootCAFileName)
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"adminUser", "nonAdminUser", "user1"})
+	adminCert, adminSigner := testutils.LoadTestCrypto(t, cryptoDir, "adminUser")
+	nonAdminCert, nonAdminSigner := testutils.LoadTestCrypto(t, cryptoDir, "nonAdminUser")
+	user1Cert, _ := testutils.LoadTestCrypto(t, cryptoDir, "nonAdminUser")
+	caCert, _ := testutils.LoadTestCA(t, cryptoDir, testutils.RootCAFileName)
 
 	nonAdminUser := &types.User{
 		Id:          "nonAdminUser",
@@ -405,12 +405,12 @@ func TestValidateEntryFieldsInWrites(t *testing.T) {
 	t.Parallel()
 
 	userID := "alice"
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice"})
-	aliceCert, _ := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
-	caCert, _ := testutils.LoadTestClientCA(t, cryptoDir, testutils.RootCAFileName)
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice"})
+	aliceCert, _ := testutils.LoadTestCrypto(t, cryptoDir, "alice")
+	caCert, _ := testutils.LoadTestCA(t, cryptoDir, testutils.RootCAFileName)
 
-	untrustedCryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice"})
-	untrustedAliceCert, _ := testutils.LoadTestClientCrypto(t, untrustedCryptoDir, "alice")
+	untrustedCryptoDir := testutils.GenerateTestCrypto(t, []string{"alice"})
+	untrustedAliceCert, _ := testutils.LoadTestCrypto(t, untrustedCryptoDir, "alice")
 
 	tests := []struct {
 		name           string

--- a/internal/txvalidation/validator_test.go
+++ b/internal/txvalidation/validator_test.go
@@ -79,10 +79,10 @@ func newValidatorTestEnv(t *testing.T) *validatorTestEnv {
 func TestValidateGenesisBlock(t *testing.T) {
 	t.Parallel()
 
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"admin1", "node1"})
-	adminCert, _ := testutils.LoadTestClientCrypto(t, cryptoDir, "admin1")
-	nodeCert, _ := testutils.LoadTestClientCrypto(t, cryptoDir, "node1")
-	caCert, _ := testutils.LoadTestClientCA(t, cryptoDir, testutils.RootCAFileName)
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"admin1", "node1"})
+	adminCert, _ := testutils.LoadTestCrypto(t, cryptoDir, "admin1")
+	nodeCert, _ := testutils.LoadTestCrypto(t, cryptoDir, "node1")
+	caCert, _ := testutils.LoadTestCA(t, cryptoDir, testutils.RootCAFileName)
 
 	//TODO test when admin and node cert are not signed by correct CA
 
@@ -356,8 +356,8 @@ func TestValidateGenesisBlock(t *testing.T) {
 func TestValidateDataBlock(t *testing.T) {
 	t.Parallel()
 
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"operatingUser"})
-	userCert, userSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "operatingUser")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"operatingUser"})
+	userCert, userSigner := testutils.LoadTestCrypto(t, cryptoDir, "operatingUser")
 
 	addUserWithCorrectPrivilege := func(db worldstate.DB) {
 		user := &types.User{
@@ -657,9 +657,9 @@ func TestValidateDataBlock(t *testing.T) {
 func TestValidateUserBlock(t *testing.T) {
 	t.Parallel()
 
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"adminUser"})
-	adminCert, adminSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "adminUser")
-	caCert, _ := testutils.LoadTestClientCA(t, cryptoDir, testutils.RootCAFileName)
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"adminUser"})
+	adminCert, adminSigner := testutils.LoadTestCrypto(t, cryptoDir, "adminUser")
+	caCert, _ := testutils.LoadTestCA(t, cryptoDir, testutils.RootCAFileName)
 	require.True(t, caCert.IsCA)
 
 	adminUser := &types.User{
@@ -800,8 +800,8 @@ func TestValidateUserBlock(t *testing.T) {
 func TestValidateDBBlock(t *testing.T) {
 	t.Parallel()
 
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"userWithMorePrivilege", "userWithLessPrivilege"})
-	adminCert, adminSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "userWithMorePrivilege")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"userWithMorePrivilege", "userWithLessPrivilege"})
+	adminCert, adminSigner := testutils.LoadTestCrypto(t, cryptoDir, "userWithMorePrivilege")
 
 	setup := func(db worldstate.DB) {
 		userWithMorePrivilege := &types.User{
@@ -920,11 +920,11 @@ func TestValidateDBBlock(t *testing.T) {
 func TestValidateConfigBlock(t *testing.T) {
 	t.Parallel()
 
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"adminUser", "admin1", "node1"})
-	userCert, userSigner := testutils.LoadTestClientCrypto(t, cryptoDir, "adminUser")
-	adminCert, _ := testutils.LoadTestClientCrypto(t, cryptoDir, "admin1")
-	nodeCert, _ := testutils.LoadTestClientCrypto(t, cryptoDir, "node1")
-	caCert, _ := testutils.LoadTestClientCA(t, cryptoDir, testutils.RootCAFileName)
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"adminUser", "admin1", "node1"})
+	userCert, userSigner := testutils.LoadTestCrypto(t, cryptoDir, "adminUser")
+	adminCert, _ := testutils.LoadTestCrypto(t, cryptoDir, "admin1")
+	nodeCert, _ := testutils.LoadTestCrypto(t, cryptoDir, "node1")
+	caCert, _ := testutils.LoadTestCA(t, cryptoDir, testutils.RootCAFileName)
 
 	setup := func(db worldstate.DB) {
 		adminUser := &types.User{

--- a/pkg/certificateauthority/ca_chain_test.go
+++ b/pkg/certificateauthority/ca_chain_test.go
@@ -13,10 +13,10 @@ import (
 )
 
 func TestNewCACertCollection(t *testing.T) {
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"user", "node"}, true)
-	userCert, _ := testutils.LoadTestClientCrypto(t, cryptoDir, "user")
-	caCert, _ := testutils.LoadTestClientCA(t, cryptoDir, testutils.RootCAFileName)
-	midCaCert, _ := testutils.LoadTestClientCA(t, cryptoDir, testutils.IntermediateCAFileName)
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"user", "node"}, true)
+	userCert, _ := testutils.LoadTestCrypto(t, cryptoDir, "user")
+	caCert, _ := testutils.LoadTestCA(t, cryptoDir, testutils.RootCAFileName)
+	midCaCert, _ := testutils.LoadTestCA(t, cryptoDir, testutils.IntermediateCAFileName)
 
 	t.Run("valid root CA certificate", func(t *testing.T) {
 		caCertCollection, err := NewCACertCollection([][]byte{caCert.Raw}, nil)
@@ -58,14 +58,14 @@ func TestNewCACertCollection(t *testing.T) {
 
 func TestCACertCollection_VerifyLeafCert(t *testing.T) {
 	// Trusted CA
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"user"})
-	userCert, _ := testutils.LoadTestClientCrypto(t, cryptoDir, "user")
-	caCert, _ := testutils.LoadTestClientCA(t, cryptoDir, testutils.RootCAFileName)
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"user"})
+	userCert, _ := testutils.LoadTestCrypto(t, cryptoDir, "user")
+	caCert, _ := testutils.LoadTestCA(t, cryptoDir, testutils.RootCAFileName)
 
 	// Generate certificates from a different CA
-	untrustedCryptoDir := testutils.GenerateTestClientCrypto(t, []string{"user", "node"})
-	untrustedUserCert, _ := testutils.LoadTestClientCrypto(t, untrustedCryptoDir, "user")
-	untrustedCaCert, _ := testutils.LoadTestClientCA(t, untrustedCryptoDir, testutils.RootCAFileName)
+	untrustedCryptoDir := testutils.GenerateTestCrypto(t, []string{"user", "node"})
+	untrustedUserCert, _ := testutils.LoadTestCrypto(t, untrustedCryptoDir, "user")
+	untrustedCaCert, _ := testutils.LoadTestCA(t, untrustedCryptoDir, testutils.RootCAFileName)
 
 	caCertCollection, err := NewCACertCollection([][]byte{caCert.Raw}, nil)
 	require.NoError(t, err)
@@ -96,10 +96,10 @@ func TestCACertCollection_VerifyLeafCert(t *testing.T) {
 
 // Check the internal consistency of CA chains provided to the constructor.
 func TestCACertCollection_VerifyCollection(t *testing.T) {
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice"}, true)
-	aliceCert, _ := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
-	rootCACert, _ := testutils.LoadTestClientCA(t, cryptoDir, testutils.RootCAFileName)
-	midCACert, _ := testutils.LoadTestClientCA(t, cryptoDir, testutils.IntermediateCAFileName)
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice"}, true)
+	aliceCert, _ := testutils.LoadTestCrypto(t, cryptoDir, "alice")
+	rootCACert, _ := testutils.LoadTestCA(t, cryptoDir, testutils.RootCAFileName)
+	midCACert, _ := testutils.LoadTestCA(t, cryptoDir, testutils.IntermediateCAFileName)
 
 	assert.NoError(t, midCACert.CheckSignatureFrom(rootCACert))
 	assert.NoError(t, rootCACert.CheckSignatureFrom(rootCACert))
@@ -110,10 +110,10 @@ func TestCACertCollection_VerifyCollection(t *testing.T) {
 	t.Logf("mid: SN: %d AKI: %x SKI: %x, I: %s, S: %s", midCACert.SerialNumber, midCACert.AuthorityKeyId, midCACert.SubjectKeyId, midCACert.Issuer, midCACert.Subject)
 	t.Logf("user: SN: %d AKI: %x SKI: %x, I: %s, S: %s", aliceCert.SerialNumber, aliceCert.AuthorityKeyId, aliceCert.SubjectKeyId, aliceCert.Issuer, aliceCert.Subject)
 
-	cryptoDir2 := testutils.GenerateTestClientCrypto(t, []string{"bob"}, true)
-	bobCert, _ := testutils.LoadTestClientCrypto(t, cryptoDir2, "bob")
-	rootCACert2, _ := testutils.LoadTestClientCA(t, cryptoDir2, testutils.RootCAFileName)
-	midCACert2, _ := testutils.LoadTestClientCA(t, cryptoDir2, testutils.IntermediateCAFileName)
+	cryptoDir2 := testutils.GenerateTestCrypto(t, []string{"bob"}, true)
+	bobCert, _ := testutils.LoadTestCrypto(t, cryptoDir2, "bob")
+	rootCACert2, _ := testutils.LoadTestCA(t, cryptoDir2, testutils.RootCAFileName)
+	midCACert2, _ := testutils.LoadTestCA(t, cryptoDir2, testutils.IntermediateCAFileName)
 
 	assert.NoError(t, midCACert2.CheckSignatureFrom(rootCACert2))
 	assert.NoError(t, rootCACert2.CheckSignatureFrom(rootCACert2))
@@ -192,7 +192,7 @@ func TestCACertCollection_VerifyCollection(t *testing.T) {
 }
 
 func TestLoadCAConfig(t *testing.T) {
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"user", "node"}, true)
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"user", "node"}, true)
 
 	rootCAFileName := path.Join(cryptoDir, testutils.RootCAFileName+".pem")
 	interCAFileName := path.Join(cryptoDir, testutils.IntermediateCAFileName+".pem")

--- a/pkg/cryptoservice/signer_test.go
+++ b/pkg/cryptoservice/signer_test.go
@@ -25,8 +25,8 @@ func TestSignQuery(t *testing.T) {
 		Name:          "unit-test",
 	})
 	require.NoError(t, err)
-	cryptoDir := testutils.GenerateTestClientCrypto(t, []string{"alice"})
-	cert, signer := testutils.LoadTestClientCrypto(t, cryptoDir, "alice")
+	cryptoDir := testutils.GenerateTestCrypto(t, []string{"alice"})
+	cert, signer := testutils.LoadTestCrypto(t, cryptoDir, "alice")
 
 	userDB := &mocks.UserDBQuerier{}
 	sigVerifier := cryptoservice.NewVerifier(userDB, lg)

--- a/pkg/server/testutils/crypto_utils.go
+++ b/pkg/server/testutils/crypto_utils.go
@@ -159,7 +159,7 @@ func getTestdataCert(t *testing.T, pathToCert string) *x509.Certificate {
 	return cert
 }
 
-func GenerateTestClientCrypto(t *testing.T, names []string, withIntermediateCA ...bool) string {
+func GenerateTestCrypto(t *testing.T, names []string, withIntermediateCA ...bool) string {
 	withInterCA := false
 	if len(withIntermediateCA) > 0 {
 		withInterCA = withIntermediateCA[0]
@@ -228,7 +228,7 @@ func GenerateTestClientCrypto(t *testing.T, names []string, withIntermediateCA .
 	return tempDir
 }
 
-func LoadTestClientCrypto(t *testing.T, tempDir, name string) (*x509.Certificate, crypto.Signer) {
+func LoadTestCrypto(t *testing.T, tempDir, name string) (*x509.Certificate, crypto.Signer) {
 	cert := getTestdataCert(t, path.Join(tempDir, name+".pem"))
 	signer, err := crypto.NewSigner(
 		&crypto.SignerOptions{
@@ -240,7 +240,7 @@ func LoadTestClientCrypto(t *testing.T, tempDir, name string) (*x509.Certificate
 	return cert, signer
 }
 
-func LoadTestClientCA(t *testing.T, tempDir, name string) (cert *x509.Certificate, key []byte) {
+func LoadTestCA(t *testing.T, tempDir, name string) (cert *x509.Certificate, key []byte) {
 	cert = getTestdataCert(t, path.Join(tempDir, name+".pem"))
 	require.True(t, cert.IsCA)
 


### PR DESCRIPTION
As follow-up to TLS pr, added renaming to Create/Load test certificates utility methods.

Signed-off-by: Gennady Laventman <gennady@il.ibm.com>