### PR TITLE
Restart after reconfig: add node

### DIFF
--- a/internal/bcdb/db.go
+++ b/internal/bcdb/db.go
@@ -36,7 +36,7 @@ type DB interface {
 	// Height returns ledger height
 	Height() (uint64, error)
 
-	// IsLeader returns whether the this server is the leader
+	// IsLeader returns whether this server is the leader
 	IsLeader() *ierrors.NotLeaderError
 
 	// DoesUserExist checks whenever user with given userID exists


### PR DESCRIPTION
After adding a node, and restarting the server, the block replicator needs
to avoid re-committing a block that was created during membership config changes,
but apply the 'ConfChangeV2' to the raft state machine. This may happen when:
 - existing nodes apply a config change but then restart from a snapshot that happened prior to the config change block;
 - a node joins an existing cluster, as on-boarding brings all the ledger from a remote peer, and then we start raft.

 must avoid re-committing the block,
Signed-off-by: Yoav Tock <tock@il.ibm.com>