### PR TITLE
fix backward link to deleted key in provenance

### DIFF
--- a/internal/provenance/commit_and_query.go
+++ b/internal/provenance/commit_and_query.go
@@ -9,11 +9,11 @@ import (
 	"sort"
 	"strings"
 
-	interrors "github.com/hyperledger-labs/orion-server/internal/errors"
-	"github.com/hyperledger-labs/orion-server/pkg/types"
 	"github.com/cayleygraph/cayley"
 	"github.com/cayleygraph/cayley/graph"
 	"github.com/cayleygraph/quad"
+	interrors "github.com/hyperledger-labs/orion-server/internal/errors"
+	"github.com/hyperledger-labs/orion-server/pkg/types"
 	"github.com/pkg/errors"
 )
 
@@ -153,7 +153,7 @@ func (s *Store) addWrites(tx *TxDataForProvenance, batch graph.BatchWriter) erro
 			// old version would not have been passed if it was deleted in the worldstate database already
 			// but we can find the old version from the provenance store even if it was deleted already
 			s.logger.Debug("fetching last deleted version of key [" + actualKey + "] from db [" + tx.DBName + "]")
-			lastVer, err := s.getLastDeletedVersion(tx.DBName, write.Key)
+			lastVer, err := s.getLastDeletedVersion(tx.DBName, actualKey)
 			if err != nil {
 				return err
 			}

--- a/internal/provenance/commit_and_query_test.go
+++ b/internal/provenance/commit_and_query_test.go
@@ -220,10 +220,6 @@ func setup(t *testing.T, s *Store) {
 					BlockNum: 3,
 					TxNum:    0,
 				},
-				"key3": {
-					BlockNum: 1,
-					TxNum:    1,
-				},
 			},
 		},
 	}
@@ -240,16 +236,10 @@ func setup(t *testing.T, s *Store) {
 					Value: []byte("value5"),
 					Metadata: &types.Metadata{
 						Version: &types.Version{
-							BlockNum: 4,
+							BlockNum: 5,
 							TxNum:    0,
 						},
 					},
-				},
-			},
-			OldVersionOfWrites: map[string]*types.Version{
-				"key1": {
-					BlockNum: 3,
-					TxNum:    0,
 				},
 			},
 		},
@@ -263,7 +253,7 @@ func setup(t *testing.T, s *Store) {
 			TxID:    "tx50",
 			Deletes: map[string]*types.Version{
 				"key1": {
-					BlockNum: 4,
+					BlockNum: 5,
 					TxNum:    0,
 				},
 			},
@@ -405,7 +395,7 @@ func TestGetValues(t *testing.T) {
 					Value: []byte("value5"),
 					Metadata: &types.Metadata{
 						Version: &types.Version{
-							BlockNum: 4,
+							BlockNum: 5,
 							TxNum:    0,
 						},
 					},
@@ -753,7 +743,7 @@ func TestGetValuesWrittenByUser(t *testing.T) {
 					Value: []byte("value5"),
 					Metadata: &types.Metadata{
 						Version: &types.Version{
-							BlockNum: 4,
+							BlockNum: 5,
 							TxNum:    0,
 						},
 					},
@@ -840,7 +830,7 @@ func TestGetNextValues(t *testing.T) {
 					Value: []byte("value5"),
 					Metadata: &types.Metadata{
 						Version: &types.Version{
-							BlockNum: 4,
+							BlockNum: 5,
 							TxNum:    0,
 						},
 					},
@@ -870,7 +860,7 @@ func TestGetNextValues(t *testing.T) {
 					Value: []byte("value5"),
 					Metadata: &types.Metadata{
 						Version: &types.Version{
-							BlockNum: 4,
+							BlockNum: 5,
 							TxNum:    0,
 						},
 					},
@@ -891,7 +881,7 @@ func TestGetNextValues(t *testing.T) {
 					Value: []byte("value5"),
 					Metadata: &types.Metadata{
 						Version: &types.Version{
-							BlockNum: 4,
+							BlockNum: 5,
 							TxNum:    0,
 						},
 					},
@@ -903,7 +893,7 @@ func TestGetNextValues(t *testing.T) {
 			dbName: "db1",
 			key:    "key1",
 			version: &types.Version{
-				BlockNum: 4,
+				BlockNum: 5,
 				TxNum:    0,
 			},
 			limit:          -1,
@@ -1074,7 +1064,7 @@ func TestGetPreviousValues(t *testing.T) {
 			dbName: "db1",
 			key:    "key1",
 			version: &types.Version{
-				BlockNum: 4,
+				BlockNum: 5,
 				TxNum:    0,
 			},
 			limit: 2,
@@ -1153,7 +1143,7 @@ func TestGetDeletedValues(t *testing.T) {
 					Value: []byte("value5"),
 					Metadata: &types.Metadata{
 						Version: &types.Version{
-							BlockNum: 4,
+							BlockNum: 5,
 							TxNum:    0,
 						},
 					},
@@ -1215,7 +1205,7 @@ func TestGetValuesDeletedByUser(t *testing.T) {
 					Value: []byte("value5"),
 					Metadata: &types.Metadata{
 						Version: &types.Version{
-							BlockNum: 4,
+							BlockNum: 5,
 							TxNum:    0,
 						},
 					},
@@ -1340,14 +1330,14 @@ func TestGetMostRecentValueAtOrBelow(t *testing.T) {
 			dbName: "db1",
 			key:    "key1",
 			version: &types.Version{
-				BlockNum: 4,
+				BlockNum: 5,
 				TxNum:    0,
 			},
 			expectedValue: &types.ValueWithMetadata{
 				Value: []byte("value5"),
 				Metadata: &types.Metadata{
 					Version: &types.Version{
-						BlockNum: 4,
+						BlockNum: 5,
 						TxNum:    0,
 					},
 				},
@@ -1401,7 +1391,7 @@ func TestGetMostRecentValueAtOrBelow(t *testing.T) {
 				Value: []byte("value5"),
 				Metadata: &types.Metadata{
 					Version: &types.Version{
-						BlockNum: 4,
+						BlockNum: 5,
 						TxNum:    0,
 					},
 				},


### PR DESCRIPTION
When the key is deleted from the world state in
a one block and the same key is added in the future
block, there should be two links (previous/next) between old deleted
value and the new value. Due to a mistake in the unit-test,
we missed to detect the bug in the production code.

Now with the integration test, we could detect this bug.
To get the last deleted value to construct the next/previous
link with the new value, we need to pass the correct key. The
existing code passes the incorrect key to find the last deleted
key node.