### PR TITLE
provenance acl: for operations APIs

### DIFF
--- a/internal/bcdb/db.go
+++ b/internal/bcdb/db.go
@@ -140,14 +140,14 @@ type DB interface {
 	// by the limit parameters.
 	GetNextValues(dbname, key string, version *types.Version) (*types.GetHistoricalDataResponseEnvelope, error)
 
-	// GetValuesReadByUser returns all values read by a given user
-	GetValuesReadByUser(userID string) (*types.GetDataProvenanceResponseEnvelope, error)
+	// GetValuesReadByUser returns all values read by a given targetUserID
+	GetValuesReadByUser(querierUserID, targetUserID string) (*types.GetDataProvenanceResponseEnvelope, error)
 
-	// GetValuesWrittenByUser returns all values written by a given user
-	GetValuesWrittenByUser(userID string) (*types.GetDataProvenanceResponseEnvelope, error)
+	// GetValuesWrittenByUser returns all values written by a targetUserID
+	GetValuesWrittenByUser(querierUserID, targetUserID string) (*types.GetDataProvenanceResponseEnvelope, error)
 
-	// GetValuesDeletedByUser returns all values deleted by a given user
-	GetValuesDeletedByUser(userID string) (*types.GetDataProvenanceResponseEnvelope, error)
+	// GetValuesDeletedByUser returns all values deleted by a targetUserID
+	GetValuesDeletedByUser(querierUserID, targetUserID string) (*types.GetDataProvenanceResponseEnvelope, error)
 
 	// GetReaders returns all userIDs who have accessed a given key as well as the access frequency
 	GetReaders(dbName, key string) (*types.GetDataReadersResponseEnvelope, error)
@@ -155,8 +155,8 @@ type DB interface {
 	// GetWriters returns all userIDs who have updated a given key as well as the access frequency
 	GetWriters(dbName, key string) (*types.GetDataWritersResponseEnvelope, error)
 
-	// GetTxIDsSubmittedByUser returns all ids of all transactions submitted by a given user
-	GetTxIDsSubmittedByUser(userID string) (*types.GetTxIDsSubmittedByResponseEnvelope, error)
+	// GetTxIDsSubmittedByUser returns all ids of all transactions submitted by a targetUserID
+	GetTxIDsSubmittedByUser(querierUserID, targetUserID string) (*types.GetTxIDsSubmittedByResponseEnvelope, error)
 
 	// GetTxReceipt returns transaction receipt - block header of ledger block that contains the transaction
 	// and transaction index inside the block
@@ -280,6 +280,7 @@ func NewDB(conf *config.Configurations, logger *logger.SugarLogger) (DB, error) 
 	provenanceQueryProcessor := newProvenanceQueryProcessor(
 		&provenanceQueryProcessorConfig{
 			provenanceStore: provenanceStore,
+			identityQuerier: querier,
 			logger:          logger,
 		},
 	)
@@ -818,9 +819,9 @@ func (d *db) GetNextValues(dbName, key string, version *types.Version) (*types.G
 	}, nil
 }
 
-// GetValuesReadByUser returns all values read by a given user
-func (d *db) GetValuesReadByUser(userID string) (*types.GetDataProvenanceResponseEnvelope, error) {
-	readByUser, err := d.provenanceQueryProcessor.GetValuesReadByUser(userID)
+// GetValuesReadByUser returns all values read by a given targetUserID
+func (d *db) GetValuesReadByUser(querierUserID, targetUserID string) (*types.GetDataProvenanceResponseEnvelope, error) {
+	readByUser, err := d.provenanceQueryProcessor.GetValuesReadByUser(querierUserID, targetUserID)
 	if err != nil {
 		return nil, err
 	}
@@ -837,9 +838,9 @@ func (d *db) GetValuesReadByUser(userID string) (*types.GetDataProvenanceRespons
 	}, nil
 }
 
-// GetValuesWrittenByUser returns all values written by a given user
-func (d *db) GetValuesWrittenByUser(userID string) (*types.GetDataProvenanceResponseEnvelope, error) {
-	writtenByUser, err := d.provenanceQueryProcessor.GetValuesWrittenByUser(userID)
+// GetValuesWrittenByUser returns all values written by a given targetUserID
+func (d *db) GetValuesWrittenByUser(querierUserID, targetUserID string) (*types.GetDataProvenanceResponseEnvelope, error) {
+	writtenByUser, err := d.provenanceQueryProcessor.GetValuesWrittenByUser(querierUserID, targetUserID)
 	if err != nil {
 		return nil, err
 	}
@@ -856,9 +857,9 @@ func (d *db) GetValuesWrittenByUser(userID string) (*types.GetDataProvenanceResp
 	}, nil
 }
 
-// GetValuesDeletedByUser returns all values deleted by a given user
-func (d *db) GetValuesDeletedByUser(userID string) (*types.GetDataProvenanceResponseEnvelope, error) {
-	deletedByUser, err := d.provenanceQueryProcessor.GetValuesDeletedByUser(userID)
+// GetValuesDeletedByUser returns all values deleted by a given targetUserID
+func (d *db) GetValuesDeletedByUser(querierUserID, targetUserID string) (*types.GetDataProvenanceResponseEnvelope, error) {
+	deletedByUser, err := d.provenanceQueryProcessor.GetValuesDeletedByUser(querierUserID, targetUserID)
 	if err != nil {
 		return nil, err
 	}
@@ -913,9 +914,9 @@ func (d *db) GetWriters(dbName, key string) (*types.GetDataWritersResponseEnvelo
 	}, nil
 }
 
-// GetTxIDsSubmittedByUser returns all ids of all transactions submitted by a given user
-func (d *db) GetTxIDsSubmittedByUser(userID string) (*types.GetTxIDsSubmittedByResponseEnvelope, error) {
-	submittedByUser, err := d.provenanceQueryProcessor.GetTxIDsSubmittedByUser(userID)
+// GetTxIDsSubmittedByUser returns all ids of all transactions submitted by a given targetUserID
+func (d *db) GetTxIDsSubmittedByUser(querierUserID, targetUserID string) (*types.GetTxIDsSubmittedByResponseEnvelope, error) {
+	submittedByUser, err := d.provenanceQueryProcessor.GetTxIDsSubmittedByUser(querierUserID, targetUserID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/bcdb/mocks/db.go
+++ b/internal/bcdb/mocks/db.go
@@ -492,13 +492,13 @@ func (_m *DB) GetReaders(dbName string, key string) (*types.GetDataReadersRespon
 	return r0, r1
 }
 
-// GetTxIDsSubmittedByUser provides a mock function with given fields: userID
-func (_m *DB) GetTxIDsSubmittedByUser(userID string) (*types.GetTxIDsSubmittedByResponseEnvelope, error) {
-	ret := _m.Called(userID)
+// GetTxIDsSubmittedByUser provides a mock function with given fields: querierUserID, targetUserID
+func (_m *DB) GetTxIDsSubmittedByUser(querierUserID string, targetUserID string) (*types.GetTxIDsSubmittedByResponseEnvelope, error) {
+	ret := _m.Called(querierUserID, targetUserID)
 
 	var r0 *types.GetTxIDsSubmittedByResponseEnvelope
-	if rf, ok := ret.Get(0).(func(string) *types.GetTxIDsSubmittedByResponseEnvelope); ok {
-		r0 = rf(userID)
+	if rf, ok := ret.Get(0).(func(string, string) *types.GetTxIDsSubmittedByResponseEnvelope); ok {
+		r0 = rf(querierUserID, targetUserID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*types.GetTxIDsSubmittedByResponseEnvelope)
@@ -506,8 +506,8 @@ func (_m *DB) GetTxIDsSubmittedByUser(userID string) (*types.GetTxIDsSubmittedBy
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(userID)
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(querierUserID, targetUserID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -630,13 +630,13 @@ func (_m *DB) GetValues(dbName string, key string) (*types.GetHistoricalDataResp
 	return r0, r1
 }
 
-// GetValuesDeletedByUser provides a mock function with given fields: userID
-func (_m *DB) GetValuesDeletedByUser(userID string) (*types.GetDataProvenanceResponseEnvelope, error) {
-	ret := _m.Called(userID)
+// GetValuesDeletedByUser provides a mock function with given fields: querierUserID, targetUserID
+func (_m *DB) GetValuesDeletedByUser(querierUserID string, targetUserID string) (*types.GetDataProvenanceResponseEnvelope, error) {
+	ret := _m.Called(querierUserID, targetUserID)
 
 	var r0 *types.GetDataProvenanceResponseEnvelope
-	if rf, ok := ret.Get(0).(func(string) *types.GetDataProvenanceResponseEnvelope); ok {
-		r0 = rf(userID)
+	if rf, ok := ret.Get(0).(func(string, string) *types.GetDataProvenanceResponseEnvelope); ok {
+		r0 = rf(querierUserID, targetUserID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*types.GetDataProvenanceResponseEnvelope)
@@ -644,8 +644,8 @@ func (_m *DB) GetValuesDeletedByUser(userID string) (*types.GetDataProvenanceRes
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(userID)
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(querierUserID, targetUserID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -653,13 +653,13 @@ func (_m *DB) GetValuesDeletedByUser(userID string) (*types.GetDataProvenanceRes
 	return r0, r1
 }
 
-// GetValuesReadByUser provides a mock function with given fields: userID
-func (_m *DB) GetValuesReadByUser(userID string) (*types.GetDataProvenanceResponseEnvelope, error) {
-	ret := _m.Called(userID)
+// GetValuesReadByUser provides a mock function with given fields: querierUserID, targetUserID
+func (_m *DB) GetValuesReadByUser(querierUserID string, targetUserID string) (*types.GetDataProvenanceResponseEnvelope, error) {
+	ret := _m.Called(querierUserID, targetUserID)
 
 	var r0 *types.GetDataProvenanceResponseEnvelope
-	if rf, ok := ret.Get(0).(func(string) *types.GetDataProvenanceResponseEnvelope); ok {
-		r0 = rf(userID)
+	if rf, ok := ret.Get(0).(func(string, string) *types.GetDataProvenanceResponseEnvelope); ok {
+		r0 = rf(querierUserID, targetUserID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*types.GetDataProvenanceResponseEnvelope)
@@ -667,8 +667,8 @@ func (_m *DB) GetValuesReadByUser(userID string) (*types.GetDataProvenanceRespon
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(userID)
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(querierUserID, targetUserID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -676,13 +676,13 @@ func (_m *DB) GetValuesReadByUser(userID string) (*types.GetDataProvenanceRespon
 	return r0, r1
 }
 
-// GetValuesWrittenByUser provides a mock function with given fields: userID
-func (_m *DB) GetValuesWrittenByUser(userID string) (*types.GetDataProvenanceResponseEnvelope, error) {
-	ret := _m.Called(userID)
+// GetValuesWrittenByUser provides a mock function with given fields: querierUserID, targetUserID
+func (_m *DB) GetValuesWrittenByUser(querierUserID string, targetUserID string) (*types.GetDataProvenanceResponseEnvelope, error) {
+	ret := _m.Called(querierUserID, targetUserID)
 
 	var r0 *types.GetDataProvenanceResponseEnvelope
-	if rf, ok := ret.Get(0).(func(string) *types.GetDataProvenanceResponseEnvelope); ok {
-		r0 = rf(userID)
+	if rf, ok := ret.Get(0).(func(string, string) *types.GetDataProvenanceResponseEnvelope); ok {
+		r0 = rf(querierUserID, targetUserID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*types.GetDataProvenanceResponseEnvelope)
@@ -690,8 +690,8 @@ func (_m *DB) GetValuesWrittenByUser(userID string) (*types.GetDataProvenanceRes
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(userID)
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(querierUserID, targetUserID)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
Operations such as reads, writes, and deleted
performed by an user can be retrieved either by
the respective user or by the admin only.

Signed-off-by: senthil <cendhu@gmail.com>