### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,8 +5,13 @@ Maintainers
 
 | Name | GitHub | email
 |------|--------|----------------------
-| Artem Barger | c0rwin | <artem@bargr.net>
-| Dany Moshkovich | dany-moshkovich | <MDANY@il.ibm.com>
 | Gennady Laventman | gennadylaventman | <gennady@laventman.net>
 | Senthilnathan Natarajan | cendhu | <cendhu@gmail.com>
 | Yoav Tock | tock-ibm | <TOCK@il.ibm.com>
+
+**Emertius Maintainers**
+
+| Name | GitHub | email
+|------|--------|----------------------
+| Artem Barger | c0rwin | <artem@bargr.net>
+| Dany Moshkovich | dany-moshkovich | <MDANY@il.ibm.com>


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

https://github.com/hyperledger/toc/issues/32

Signed-off-by: Ry Jones <ry@linux.com>