### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/cmd/signer/signer_test.go
+++ b/cmd/signer/signer_test.go
@@ -34,13 +34,7 @@ func TestSigner(t *testing.T) {
 	})
 
 	t.Run("correct args", func(t *testing.T) {
-		tempDir, err := ioutil.TempDir("/tmp", "crypto")
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			if err := os.RemoveAll(tempDir); err != nil {
-				t.Errorf("error while removing test directory: %v", err)
-			}
-		})
+		tempDir := t.TempDir()
 
 		adminCert, adminKey := createAdminCreds(t, tempDir)
 		data := "'{\"user_id\":\"admin\"}'"

--- a/config/join_block_test.go
+++ b/config/join_block_test.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path"
 	"testing"
 
@@ -13,9 +12,7 @@ import (
 )
 
 func TestJoinBlock(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test-config-join-block")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	t.Run("empty-join-block-path", func(t *testing.T) {
 		joinBlock, err := readJoinBlock("")

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,8 @@ go 1.16
 require (
 	github.com/cayleygraph/cayley v0.7.7
 	github.com/cayleygraph/quad v1.1.0
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.2
 	github.com/golang/snappy v0.0.1
-	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.4
 	github.com/hidal-go/hidalgo v0.0.0-20201109092204-05749a6d73df

--- a/internal/bcdb/config_query_test.go
+++ b/internal/bcdb/config_query_test.go
@@ -5,8 +5,6 @@ package bcdb
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
@@ -36,8 +34,7 @@ type configQueryTestEnv struct {
 func newConfigQueryTestEnv(t *testing.T) *configQueryTestEnv {
 	nodeID := "node1"
 
-	path, err := ioutil.TempDir("/tmp", "queryProcessor")
-	require.NoError(t, err)
+	path := t.TempDir()
 
 	c := &logger.Config{
 		Level:         "info",
@@ -55,10 +52,6 @@ func newConfigQueryTestEnv(t *testing.T) *configQueryTestEnv {
 		},
 	)
 	if err != nil {
-		if err := os.RemoveAll(path); err != nil {
-			t.Errorf("failed to remove %s due to %v", path, err)
-		}
-
 		t.Fatalf("failed to create a new leveldb instance, %v", err)
 	}
 
@@ -70,9 +63,6 @@ func newConfigQueryTestEnv(t *testing.T) *configQueryTestEnv {
 		},
 	)
 	if err != nil {
-		if rmErr := os.RemoveAll(path); rmErr != nil {
-			t.Errorf("error while removing directory %s, %v", path, rmErr)
-		}
 		t.Fatalf("error while creating blockstore, %v", err)
 	}
 
@@ -92,9 +82,6 @@ func newConfigQueryTestEnv(t *testing.T) *configQueryTestEnv {
 		},
 	)
 	if err != nil {
-		if rmErr := os.RemoveAll(path); rmErr != nil {
-			t.Errorf("error while removing directory %s, %v", path, rmErr)
-		}
 		t.Fatalf("error while creating provenancestore, %v", err)
 	}
 
@@ -110,9 +97,6 @@ func newConfigQueryTestEnv(t *testing.T) *configQueryTestEnv {
 		}
 		if err := trieStore.Close(); err != nil {
 			t.Errorf("error while closing triestore, %v", err)
-		}
-		if err := os.RemoveAll(path); err != nil {
-			t.Fatalf("failed to remove %s due to %v", path, err)
 		}
 	}
 

--- a/internal/bcdb/ledger_query_procesor_test.go
+++ b/internal/bcdb/ledger_query_procesor_test.go
@@ -6,8 +6,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/hyperledger-labs/orion-server/pkg/state"
@@ -39,8 +37,7 @@ type ledgerProcessorTestEnv struct {
 }
 
 func newLedgerProcessorTestEnv(t *testing.T) *ledgerProcessorTestEnv {
-	path, err := ioutil.TempDir("/tmp", "ledgerQueryProcessor")
-	require.NoError(t, err)
+	path := t.TempDir()
 
 	c := &logger.Config{
 		Level:         "info",
@@ -59,9 +56,6 @@ func newLedgerProcessorTestEnv(t *testing.T) *ledgerProcessorTestEnv {
 		},
 	)
 	if err != nil {
-		if err := os.RemoveAll(path); err != nil {
-			t.Errorf("failed to remove %s due to %v", path, err)
-		}
 		t.Fatalf("failed to create a new leveldb instance, %v", err)
 	}
 
@@ -73,9 +67,6 @@ func newLedgerProcessorTestEnv(t *testing.T) *ledgerProcessorTestEnv {
 		},
 	)
 	if err != nil {
-		if rmErr := os.RemoveAll(path); rmErr != nil {
-			t.Errorf("error while removing directory %s, %v", path, rmErr)
-		}
 		t.Fatalf("error while creating blockstore, %v", err)
 	}
 
@@ -95,9 +86,6 @@ func newLedgerProcessorTestEnv(t *testing.T) *ledgerProcessorTestEnv {
 		},
 	)
 	if err != nil {
-		if rmErr := os.RemoveAll(path); rmErr != nil {
-			t.Errorf("error while removing directory %s, %v", path, rmErr)
-		}
 		t.Fatalf("error while creating provenancestore, %v", err)
 	}
 
@@ -113,9 +101,6 @@ func newLedgerProcessorTestEnv(t *testing.T) *ledgerProcessorTestEnv {
 		}
 		if err := trieStore.Close(); err != nil {
 			t.Errorf("error while closing triestore, %v", err)
-		}
-		if err := os.RemoveAll(path); err != nil {
-			t.Fatalf("failed to remove %s due to %v", path, err)
 		}
 	}
 

--- a/internal/bcdb/path_test.go
+++ b/internal/bcdb/path_test.go
@@ -4,8 +4,6 @@ package bcdb
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,9 +11,7 @@ import (
 
 func TestPath(t *testing.T) {
 	t.Run("worldstate path", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "statedb")
-		require.NoError(t, err)
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 
 		require.Equal(
 			t,
@@ -25,9 +21,7 @@ func TestPath(t *testing.T) {
 	})
 
 	t.Run("blockstore path", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "blockstore")
-		require.NoError(t, err)
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 
 		require.Equal(
 			t,

--- a/internal/bcdb/provenance_query_processor_test.go
+++ b/internal/bcdb/provenance_query_processor_test.go
@@ -3,8 +3,6 @@
 package bcdb
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
@@ -25,8 +23,7 @@ type provenanceQueryProcessorTestEnv struct {
 }
 
 func newProvenanceQueryProcessorTestEnv(t *testing.T) *provenanceQueryProcessorTestEnv {
-	provenancePath, err := ioutil.TempDir("/tmp", "provenanceQueryProcessor")
-	require.NoError(t, err)
+	provenancePath := t.TempDir()
 
 	c := &logger.Config{
 		Level:         "info",
@@ -44,15 +41,10 @@ func newProvenanceQueryProcessorTestEnv(t *testing.T) *provenanceQueryProcessorT
 		},
 	)
 	if err != nil {
-		if err := os.RemoveAll(provenancePath); err != nil {
-			t.Errorf("failed to remove %s due to %v", provenancePath, err)
-		}
-
 		t.Fatalf("failed to create a new provenance store, %v", err)
 	}
 
-	dbPath, err := ioutil.TempDir("/tmp", "db")
-	require.NoError(t, err)
+	dbPath := t.TempDir()
 	db, err := leveldb.Open(
 		&leveldb.Config{
 			DBRootDir: dbPath,
@@ -60,10 +52,6 @@ func newProvenanceQueryProcessorTestEnv(t *testing.T) *provenanceQueryProcessorT
 		},
 	)
 	if err != nil {
-		if err := os.RemoveAll(dbPath); err != nil {
-			t.Errorf("failed to remove %s due to %v", dbPath, err)
-		}
-
 		t.Fatalf("failed to create a new leveldb instance, %v", err)
 	}
 
@@ -74,13 +62,6 @@ func newProvenanceQueryProcessorTestEnv(t *testing.T) *provenanceQueryProcessorT
 
 		if err := db.Close(); err != nil {
 			t.Errorf("failed to close leveldb: %v", err)
-		}
-		if err := os.RemoveAll(provenancePath); err != nil {
-			t.Fatalf("failed to remove %s due to %v", provenancePath, err)
-		}
-
-		if err := os.RemoveAll(dbPath); err != nil {
-			t.Fatalf("failed to remove %s due to %v", dbPath, err)
 		}
 	}
 

--- a/internal/bcdb/transaction_processor_test.go
+++ b/internal/bcdb/transaction_processor_test.go
@@ -5,7 +5,6 @@ package bcdb
 import (
 	"bytes"
 	"crypto/x509"
-	"io/ioutil"
 	"math"
 	"os"
 	"path"
@@ -219,7 +218,6 @@ func TestTransactionProcessor(t *testing.T) {
 	t.Run("commit a data transaction asynchronously", func(t *testing.T) {
 		cryptoDir, conf := testConfiguration(t)
 		require.NotEqual(t, "", cryptoDir)
-		defer os.RemoveAll(conf.LocalConfig.Server.Database.LedgerDirectory)
 		env := newTxProcessorTestEnv(t, cryptoDir, conf)
 		defer env.cleanup()
 
@@ -331,7 +329,6 @@ func TestTransactionProcessor(t *testing.T) {
 	t.Run("commit a data transaction synchronously", func(t *testing.T) {
 		cryptoDir, conf := testConfiguration(t)
 		require.NotEqual(t, "", cryptoDir)
-		defer os.RemoveAll(conf.LocalConfig.Server.Database.LedgerDirectory)
 		env := newTxProcessorTestEnv(t, cryptoDir, conf)
 		defer env.cleanup()
 
@@ -438,7 +435,6 @@ func TestTransactionProcessor(t *testing.T) {
 	t.Run("duplicate txID with the already committed transaction", func(t *testing.T) {
 		cryptoDir, conf := testConfiguration(t)
 		require.NotEqual(t, "", cryptoDir)
-		defer os.RemoveAll(conf.LocalConfig.Server.Database.LedgerDirectory)
 		env := newTxProcessorTestEnv(t, cryptoDir, conf)
 		defer env.cleanup()
 
@@ -474,7 +470,6 @@ func TestTransactionProcessor(t *testing.T) {
 	t.Run("duplicate txID with either pending or already committed transaction", func(t *testing.T) {
 		cryptoDir, conf := testConfiguration(t)
 		require.NotEqual(t, "", cryptoDir)
-		defer os.RemoveAll(conf.LocalConfig.Server.Database.LedgerDirectory)
 		env := newTxProcessorTestEnv(t, cryptoDir, conf)
 		defer env.cleanup()
 
@@ -514,7 +509,6 @@ func TestTransactionProcessor(t *testing.T) {
 	t.Run("unexpected transaction type", func(t *testing.T) {
 		cryptoDir, conf := testConfiguration(t)
 		require.NotEqual(t, "", cryptoDir)
-		defer os.RemoveAll(conf.LocalConfig.Server.Database.LedgerDirectory)
 		env := newTxProcessorTestEnv(t, cryptoDir, conf)
 		defer env.cleanup()
 
@@ -528,7 +522,6 @@ func TestTransactionProcessor(t *testing.T) {
 	t.Run("bad TxId", func(t *testing.T) {
 		cryptoDir, conf := testConfiguration(t)
 		require.NotEqual(t, "", cryptoDir)
-		defer os.RemoveAll(conf.LocalConfig.Server.Database.LedgerDirectory)
 		env := newTxProcessorTestEnv(t, cryptoDir, conf)
 		defer env.cleanup()
 
@@ -560,7 +553,6 @@ func TestTransactionProcessor(t *testing.T) {
 	t.Run("create with a join block", func(t *testing.T) {
 		cryptoDir, conf := testJoinConfiguration(t)
 		require.NotEqual(t, "", cryptoDir)
-		defer os.RemoveAll(conf.LocalConfig.Server.Database.LedgerDirectory)
 		env := newTxProcessorTestEnv(t, cryptoDir, conf)
 		require.NotNil(t, env)
 	})
@@ -568,7 +560,6 @@ func TestTransactionProcessor(t *testing.T) {
 	t.Run("get cluster status", func(t *testing.T) {
 		cryptoDir, conf := testConfiguration(t)
 		require.NotEqual(t, "", cryptoDir)
-		defer os.RemoveAll(conf.LocalConfig.Server.Database.LedgerDirectory)
 		env := newTxProcessorTestEnv(t, cryptoDir, conf)
 		defer env.cleanup()
 
@@ -586,8 +577,7 @@ func TestTransactionProcessor(t *testing.T) {
 }
 
 func testConfiguration(t *testing.T) (string, *config.Configurations) {
-	ledgerDir, err := ioutil.TempDir("/tmp", "server")
-	require.NoError(t, err)
+	ledgerDir := t.TempDir()
 
 	cryptoDir := testutils.GenerateTestCrypto(t, []string{"testUser", "bdb-node-1", "admin"})
 
@@ -667,8 +657,7 @@ func testConfiguration(t *testing.T) (string, *config.Configurations) {
 }
 
 func testJoinConfiguration(t *testing.T) (string, *config.Configurations) {
-	ledgerDir, err := ioutil.TempDir("/tmp", "server")
-	require.NoError(t, err)
+	ledgerDir := t.TempDir()
 
 	cryptoDir := testutils.GenerateTestCrypto(t, []string{"testUser", "bdb-node-1", "bdb-node-2", "admin"})
 

--- a/internal/bcdb/worldstate_query_processor_test.go
+++ b/internal/bcdb/worldstate_query_processor_test.go
@@ -5,8 +5,6 @@ package bcdb
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
@@ -29,8 +27,7 @@ type worldstateQueryProcessorTestEnv struct {
 func newWorldstateQueryProcessorTestEnv(t *testing.T) *worldstateQueryProcessorTestEnv {
 	nodeID := "test-node-id1"
 
-	path, err := ioutil.TempDir("/tmp", "queryProcessor")
-	require.NoError(t, err)
+	path := t.TempDir()
 
 	c := &logger.Config{
 		Level:         "info",
@@ -48,19 +45,12 @@ func newWorldstateQueryProcessorTestEnv(t *testing.T) *worldstateQueryProcessorT
 		},
 	)
 	if err != nil {
-		if err := os.RemoveAll(path); err != nil {
-			t.Errorf("failed to remove %s due to %v", path, err)
-		}
-
 		t.Fatalf("failed to create a new leveldb instance, %v", err)
 	}
 
 	cleanup := func(t *testing.T) {
 		if err := db.Close(); err != nil {
 			t.Errorf("failed to close leveldb: %v", err)
-		}
-		if err := os.RemoveAll(path); err != nil {
-			t.Fatalf("failed to remove %s due to %v", path, err)
 		}
 	}
 

--- a/internal/blockcreator/blockcreator_test.go
+++ b/internal/blockcreator/blockcreator_test.go
@@ -4,8 +4,6 @@ package blockcreator_test
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -43,8 +41,7 @@ func newTestEnv(t *testing.T) *testEnv {
 	logger, err := logger.New(c)
 	require.NoError(t, err)
 
-	dir, err := ioutil.TempDir("/tmp", "creator")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	dbPath := filepath.Join(dir, "leveldb")
 	db, err := leveldb.Open(
@@ -54,9 +51,6 @@ func newTestEnv(t *testing.T) *testEnv {
 		},
 	)
 	if err != nil {
-		if rmErr := os.RemoveAll(dir); rmErr != nil {
-			t.Errorf("error while removing directory %s, %v", dir, err)
-		}
 		t.Fatalf("error while creating the leveldb instance, %v", err)
 	}
 
@@ -68,9 +62,6 @@ func newTestEnv(t *testing.T) *testEnv {
 		},
 	)
 	if err != nil {
-		if rmErr := os.RemoveAll(dir); rmErr != nil {
-			t.Errorf("error while removing directory %s, %v", dir, err)
-		}
 		t.Fatalf("error while creating the block store, %v", err)
 	}
 
@@ -99,10 +90,6 @@ func newTestEnv(t *testing.T) *testEnv {
 
 		if err := blockStore.Close(); err != nil {
 			t.Errorf("failed to close the blockstore, %v", err)
-		}
-
-		if err := os.RemoveAll(dir); err != nil {
-			t.Errorf("failed to remove directory %s, %v", dir, err)
 		}
 	}
 

--- a/internal/blockprocessor/committer_test.go
+++ b/internal/blockprocessor/committer_test.go
@@ -5,8 +5,6 @@ package blockprocessor
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -43,8 +41,7 @@ func newCommitterTestEnv(t *testing.T) *committerTestEnv {
 	logger, err := logger.New(lc)
 	require.NoError(t, err)
 
-	dir, err := ioutil.TempDir("/tmp", "committer")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	dbPath := filepath.Join(dir, "leveldb")
 	db, err := leveldb.Open(
@@ -54,9 +51,6 @@ func newCommitterTestEnv(t *testing.T) *committerTestEnv {
 		},
 	)
 	if err != nil {
-		if rmErr := os.RemoveAll(dir); rmErr != nil {
-			t.Errorf("error while removing directory %s, %v", dir, rmErr)
-		}
 		t.Fatalf("error while creating leveldb, %v", err)
 	}
 
@@ -68,9 +62,6 @@ func newCommitterTestEnv(t *testing.T) *committerTestEnv {
 		},
 	)
 	if err != nil {
-		if rmErr := os.RemoveAll(dir); rmErr != nil {
-			t.Errorf("error while removing directory %s, %v", dir, rmErr)
-		}
 		t.Fatalf("error while creating blockstore, %v", err)
 	}
 
@@ -91,9 +82,6 @@ func newCommitterTestEnv(t *testing.T) *committerTestEnv {
 	)
 
 	if err != nil {
-		if rmErr := os.RemoveAll(dir); rmErr != nil {
-			t.Errorf("error while removing directory %s, %v", dir, err)
-		}
 		t.Fatalf("error while creating the block store, %v", err)
 	}
 
@@ -108,10 +96,6 @@ func newCommitterTestEnv(t *testing.T) *committerTestEnv {
 
 		if err := blockStore.Close(); err != nil {
 			t.Errorf("error while closing blockstore, %v", err)
-		}
-
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatalf("error while removing directory %s, %v", dir, err)
 		}
 	}
 

--- a/internal/blockprocessor/processor_test.go
+++ b/internal/blockprocessor/processor_test.go
@@ -7,8 +7,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -59,8 +57,7 @@ func newTestEnv(t *testing.T) *testEnv {
 	logger, err := logger.New(c)
 	require.NoError(t, err)
 
-	dir, err := ioutil.TempDir("/tmp", "validatorAndCommitter")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	dbPath := filepath.Join(dir, "leveldb")
 	db, err := leveldb.Open(
@@ -70,9 +67,6 @@ func newTestEnv(t *testing.T) *testEnv {
 		},
 	)
 	if err != nil {
-		if rmErr := os.RemoveAll(dir); rmErr != nil {
-			t.Errorf("error while removing directory %s, %v", dir, err)
-		}
 		t.Fatalf("error while creating the leveldb instance, %v", err)
 	}
 
@@ -84,9 +78,6 @@ func newTestEnv(t *testing.T) *testEnv {
 		},
 	)
 	if err != nil {
-		if rmErr := os.RemoveAll(dir); rmErr != nil {
-			t.Errorf("error while removing directory %s, %v", dir, err)
-		}
 		t.Fatalf("error while creating the block store, %v", err)
 	}
 
@@ -98,9 +89,6 @@ func newTestEnv(t *testing.T) *testEnv {
 		},
 	)
 	if err != nil {
-		if rmErr := os.RemoveAll(dir); rmErr != nil {
-			t.Errorf("error while removing directory %s, %v", dir, err)
-		}
 		t.Fatalf("error while creating the block store, %v", err)
 	}
 
@@ -113,9 +101,6 @@ func newTestEnv(t *testing.T) *testEnv {
 	)
 
 	if err != nil {
-		if rmErr := os.RemoveAll(dir); rmErr != nil {
-			t.Errorf("error while removing directory %s, %v", dir, err)
-		}
 		t.Fatalf("error while creating the block store, %v", err)
 	}
 
@@ -208,10 +193,6 @@ func newTestEnv(t *testing.T) *testEnv {
 
 		if err := blockStore.Close(); err != nil {
 			t.Errorf("failed to close the blockstore, %v", err)
-		}
-
-		if err := os.RemoveAll(dir); err != nil {
-			t.Errorf("failed to remove directory %s, %v", dir, err)
 		}
 	}
 

--- a/internal/blockstore/commit_and_query_test.go
+++ b/internal/blockstore/commit_and_query_test.go
@@ -4,7 +4,6 @@ package blockstore
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -23,8 +22,7 @@ type testEnv struct {
 }
 
 func newTestEnv(t *testing.T) *testEnv {
-	storeDir, err := ioutil.TempDir("", "blockstore")
-	require.NoError(t, err)
+	storeDir := t.TempDir()
 
 	lc := &logger.Config{
 		Level:         "debug",
@@ -42,10 +40,6 @@ func newTestEnv(t *testing.T) *testEnv {
 
 	store, err := Open(c)
 	if err != nil {
-		if rmErr := os.RemoveAll(storeDir); rmErr != nil {
-			t.Errorf("error while removing directory %s, %v", storeDir, rmErr)
-		}
-
 		t.Fatalf("error while opening store on path %s, %v", storeDir, err)
 	}
 
@@ -57,10 +51,6 @@ func newTestEnv(t *testing.T) *testEnv {
 				if err := store.Close(); err != nil {
 					t.Errorf("error while closing the store %s, %v", storeDir, err)
 				}
-			}
-
-			if err := os.RemoveAll(storeDir); err != nil {
-				t.Fatalf("error while removing directory %s, %v", storeDir, err)
 			}
 		},
 	}

--- a/internal/blockstore/open_test.go
+++ b/internal/blockstore/open_test.go
@@ -5,7 +5,6 @@ package blockstore
 import (
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -55,9 +54,7 @@ func TestOpenStore(t *testing.T) {
 	t.Run("open a new store", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "opentest")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		storeDir := filepath.Join(testDir, "new-store")
 		c := &Config{
@@ -73,9 +70,7 @@ func TestOpenStore(t *testing.T) {
 	t.Run("open while partial store exist with an empty dir", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "opentest")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		// create folders and files to mimic an existing creation but a crash before
 		// the successful completion
@@ -87,7 +82,6 @@ func TestOpenStore(t *testing.T) {
 			Logger:   logger,
 		}
 		s, err := Open(c)
-		defer os.RemoveAll(storeDir)
 		require.NoError(t, err)
 
 		assertStore(t, storeDir, s)
@@ -96,9 +90,7 @@ func TestOpenStore(t *testing.T) {
 	t.Run("open while partial store exist with a creation flag", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "opentest")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		// create folders and files to mimic an existing creation but a crash before
 		// the successful completion
@@ -125,9 +117,7 @@ func TestOpenStore(t *testing.T) {
 	t.Run("reopen an empty store", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "opentest")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		storeDir := filepath.Join(testDir, "reopen-empty-store")
 		require.NoError(t, fileops.CreateDir(storeDir))
@@ -137,7 +127,6 @@ func TestOpenStore(t *testing.T) {
 			Logger:   logger,
 		}
 		s, err := Open(c)
-		defer os.RemoveAll(storeDir)
 		require.NoError(t, err)
 
 		assertStore(t, storeDir, s)
@@ -153,12 +142,9 @@ func TestOpenStore(t *testing.T) {
 	t.Run("reopen non-empty store", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "opentest")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		storeDir := filepath.Join(testDir, "reopen-non-empty-store")
-		defer os.RemoveAll(storeDir)
 		require.NoError(t, fileops.CreateDir(storeDir))
 
 		c := &Config{
@@ -166,7 +152,6 @@ func TestOpenStore(t *testing.T) {
 			Logger:   logger,
 		}
 		s, err := Open(c)
-		defer os.RemoveAll(storeDir)
 		require.NoError(t, err)
 
 		assertStore(t, storeDir, s)

--- a/internal/comm/catchup_client_test.go
+++ b/internal/comm/catchup_client_test.go
@@ -5,8 +5,6 @@ package comm_test
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"path"
 	"strings"
 	"sync"
@@ -284,9 +282,7 @@ func TestCatchUpClient_PullBlocksLoop(t *testing.T) {
 // - Start 3rd transport with ledger at height 150,
 // - Wait until client gets them all.
 func TestCatchUpClient_PullBlocksRetry(t *testing.T) {
-	dir, err := ioutil.TempDir("", "catchup")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	var retryCount int
 	var wgRetry1 sync.WaitGroup

--- a/internal/comm/httptransport_test.go
+++ b/internal/comm/httptransport_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"path"
 	"strings"
 	"sync"
@@ -873,11 +872,7 @@ func newTestSetup(t *testing.T, numServers int) ([]*config.LocalConfiguration, *
 		nodeIDs = append(nodeIDs, fmt.Sprintf("node%d", i+1))
 	}
 	cryptoDir := testutils.GenerateTestCrypto(t, nodeIDs, true)
-	auxDir, err := ioutil.TempDir("/tmp", "UnitTestAux")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(auxDir)
-	})
+	auxDir := t.TempDir()
 
 	configs := make([]*config.LocalConfiguration, 0)
 	for i := 0; i < numServers; i++ {

--- a/internal/fileops/file_ops_test.go
+++ b/internal/fileops/file_ops_test.go
@@ -371,26 +371,15 @@ func TestSyncDir(t *testing.T) {
 func prepareTestDir(t *testing.T) string {
 	tempDir := t.TempDir()
 
-	if err := os.Mkdir(path.Join(tempDir, "dir"), 0755); err != nil {
-		t.FailNow()
-	}
-	if err := os.Mkdir(path.Join(tempDir, "dir", "a"), 0755); err != nil {
-		t.FailNow()
-	}
-	if err := os.Mkdir(path.Join(tempDir, "dir", "b"), 0755); err != nil {
-		t.FailNow()
-	}
-	if err := os.Mkdir(path.Join(tempDir, "dir", "c"), 0755); err != nil {
-		t.FailNow()
-	}
-	if err := os.Mkdir(path.Join(tempDir, "dir", "d"), 0755); err != nil {
-		t.FailNow()
-	}
-	if file, err := os.OpenFile(path.Join(tempDir, "dir", "e"), os.O_CREATE, 0644); err != nil {
-		t.FailNow()
-	} else {
-		defer file.Close()
-	}
+	require.NoError(t, os.Mkdir(path.Join(tempDir, "dir"), 0755))
+	require.NoError(t, os.Mkdir(path.Join(tempDir, "dir", "a"), 0755))
+	require.NoError(t, os.Mkdir(path.Join(tempDir, "dir", "b"), 0755))
+	require.NoError(t, os.Mkdir(path.Join(tempDir, "dir", "c"), 0755))
+	require.NoError(t, os.Mkdir(path.Join(tempDir, "dir", "d"), 0755))
+
+	file, err := os.OpenFile(path.Join(tempDir, "dir", "e"), os.O_CREATE, 0644)
+	require.NoError(t, err)
+	defer file.Close()
 
 	return tempDir
 }

--- a/internal/fileops/file_ops_test.go
+++ b/internal/fileops/file_ops_test.go
@@ -14,7 +14,6 @@ import (
 
 func TestIsDirEmpty(t *testing.T) {
 	testDir := prepareTestDir(t)
-	defer os.RemoveAll(testDir)
 
 	t.Run("non-empty directory", func(t *testing.T) {
 		isEmpty, err := IsDirEmpty(path.Join(testDir, "dir"))
@@ -39,7 +38,6 @@ func TestIsDirEmpty(t *testing.T) {
 
 func TestListSubdirs(t *testing.T) {
 	testDir := prepareTestDir(t)
-	defer os.RemoveAll(testDir)
 
 	t.Run("subdirs exist", func(t *testing.T) {
 		dirs, err := ListSubdirs(path.Join(testDir, "dir"))
@@ -64,7 +62,6 @@ func TestListSubdirs(t *testing.T) {
 
 func TestFileExists(t *testing.T) {
 	testDir := prepareTestDir(t)
-	defer os.RemoveAll(testDir)
 
 	exists, err := Exists(path.Join(testDir, "dir"))
 	require.NoError(t, err)
@@ -81,7 +78,6 @@ func TestFileExists(t *testing.T) {
 
 func TestCreateDir(t *testing.T) {
 	testDir := prepareTestDir(t)
-	defer os.RemoveAll(testDir)
 
 	require.DirExists(t, path.Join(testDir, "dir"))
 	require.NoError(t, CreateDir(path.Join(testDir, "dir")))
@@ -97,7 +93,6 @@ func TestCreateDir(t *testing.T) {
 
 func TestOpenFile(t *testing.T) {
 	testDir := prepareTestDir(t)
-	defer os.RemoveAll(testDir)
 
 	testCases := []struct {
 		description  string
@@ -142,7 +137,6 @@ func TestOpenFile(t *testing.T) {
 
 func TestCreateFile(t *testing.T) {
 	testDir := prepareTestDir(t)
-	defer os.RemoveAll(testDir)
 
 	tests := []struct {
 		name         string
@@ -182,7 +176,6 @@ func TestCreateFile(t *testing.T) {
 
 func TestRemove(t *testing.T) {
 	testDir := prepareTestDir(t)
-	defer os.RemoveAll(testDir)
 
 	var tests = []struct {
 		name        string
@@ -226,7 +219,6 @@ func TestRemove(t *testing.T) {
 
 func TestRemoveAll(t *testing.T) {
 	testDir := prepareTestDir(t)
-	defer os.RemoveAll(testDir)
 
 	var tests = []struct {
 		name     string
@@ -253,7 +245,6 @@ func TestRemoveAll(t *testing.T) {
 
 func TestWrite(t *testing.T) {
 	testDir := prepareTestDir(t)
-	defer os.RemoveAll(testDir)
 
 	setup := func() (*os.File, *os.File) {
 		contentFilePath := path.Join(testDir, "contentfile")
@@ -308,7 +299,6 @@ func TestWrite(t *testing.T) {
 
 func TestTruncate(t *testing.T) {
 	testDir := prepareTestDir(t)
-	defer os.RemoveAll(testDir)
 
 	setup := func() *os.File {
 		contentFilePath := path.Join(testDir, "contentfile")
@@ -364,7 +354,6 @@ func TestTruncate(t *testing.T) {
 
 func TestSyncDir(t *testing.T) {
 	testDir := prepareTestDir(t)
-	defer os.RemoveAll(testDir)
 
 	t.Run("green-path", func(t *testing.T) {
 		testPath := path.Join(testDir, "dir")
@@ -380,31 +369,25 @@ func TestSyncDir(t *testing.T) {
 }
 
 func prepareTestDir(t *testing.T) string {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "UnitTest-fileops")
-	require.NoError(t, err)
-
-	removeAndFailNow := func() {
-		os.RemoveAll(tempDir)
-		t.FailNow()
-	}
+	tempDir := t.TempDir()
 
 	if err := os.Mkdir(path.Join(tempDir, "dir"), 0755); err != nil {
-		removeAndFailNow()
+		t.FailNow()
 	}
 	if err := os.Mkdir(path.Join(tempDir, "dir", "a"), 0755); err != nil {
-		removeAndFailNow()
+		t.FailNow()
 	}
 	if err := os.Mkdir(path.Join(tempDir, "dir", "b"), 0755); err != nil {
-		removeAndFailNow()
+		t.FailNow()
 	}
 	if err := os.Mkdir(path.Join(tempDir, "dir", "c"), 0755); err != nil {
-		removeAndFailNow()
+		t.FailNow()
 	}
 	if err := os.Mkdir(path.Join(tempDir, "dir", "d"), 0755); err != nil {
-		removeAndFailNow()
+		t.FailNow()
 	}
 	if file, err := os.OpenFile(path.Join(tempDir, "dir", "e"), os.O_CREATE, 0644); err != nil {
-		removeAndFailNow()
+		t.FailNow()
 	} else {
 		defer file.Close()
 	}

--- a/internal/identity/querier_test.go
+++ b/internal/identity/querier_test.go
@@ -6,8 +6,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -37,8 +35,7 @@ func newTestEnv(t *testing.T) *testEnv {
 	logger, err := logger.New(c)
 	require.NoError(t, err)
 
-	dir, err := ioutil.TempDir("/tmp", "committer")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	dbPath := filepath.Join(dir, "leveldb")
 	db, err := leveldb.Open(
@@ -48,19 +45,12 @@ func newTestEnv(t *testing.T) *testEnv {
 		},
 	)
 	if err != nil {
-		if rmErr := os.RemoveAll(dir); rmErr != nil {
-			t.Errorf("error while removing directory %s, %v", dir, rmErr)
-		}
 		t.Fatalf("error while creating leveldb, %v", err)
 	}
 
 	cleanup := func() {
 		if err := db.Close(); err != nil {
 			t.Errorf("error while closing the db instance, %v", err)
-		}
-
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatalf("error while removing directory %s, %v", dir, err)
 		}
 	}
 

--- a/internal/mptrie/store/open_test.go
+++ b/internal/mptrie/store/open_test.go
@@ -1,8 +1,6 @@
 package store
 
 import (
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -24,9 +22,7 @@ func TestOpen(t *testing.T) {
 	t.Run("open a new store", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "open_test")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		storeDir := filepath.Join(testDir, "new-store")
 		c := &Config{
@@ -42,9 +38,7 @@ func TestOpen(t *testing.T) {
 	t.Run("open while partial store exist with an empty dir", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "open_test")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		// create folders and files to mimic an existing creation but a crash before
 		// the successful completion
@@ -56,7 +50,6 @@ func TestOpen(t *testing.T) {
 			Logger:   logger,
 		}
 		s, err := Open(c)
-		defer os.RemoveAll(storeDir)
 		require.NoError(t, err)
 
 		assertStore(t, storeDir, s)
@@ -65,9 +58,7 @@ func TestOpen(t *testing.T) {
 	t.Run("open while partial store exist with a creation flag", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "open_test")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		// create folders and files to mimic an existing creation but a crash before
 		// the successful completion
@@ -82,7 +73,6 @@ func TestOpen(t *testing.T) {
 			Logger:   logger,
 		}
 		s, err := Open(c)
-		defer os.RemoveAll(storeDir)
 		require.NoError(t, err)
 
 		assertStore(t, storeDir, s)
@@ -91,9 +81,7 @@ func TestOpen(t *testing.T) {
 	t.Run("reopen an empty store", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "open_test")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		storeDir := filepath.Join(testDir, "reopen-empty-store")
 
@@ -102,7 +90,6 @@ func TestOpen(t *testing.T) {
 			Logger:   logger,
 		}
 		s, err := Open(c)
-		defer os.RemoveAll(storeDir)
 		require.NoError(t, err)
 
 		assertStore(t, storeDir, s)
@@ -118,12 +105,9 @@ func TestOpen(t *testing.T) {
 	t.Run("reopen non-empty store", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "open_test")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		storeDir := filepath.Join(testDir, "reopen-non-empty-store")
-		defer os.RemoveAll(storeDir)
 		require.NoError(t, fileops.CreateDir(storeDir))
 
 		c := &Config{
@@ -131,7 +115,6 @@ func TestOpen(t *testing.T) {
 			Logger:   logger,
 		}
 		s, err := Open(c)
-		defer os.RemoveAll(storeDir)
 		require.NoError(t, err)
 
 		assertStore(t, storeDir, s)
@@ -149,16 +132,12 @@ func TestOpen(t *testing.T) {
 		require.Equal(t, uint64(999), lastBlock)
 	})
 
-
 	t.Run("open a disabled store", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "open_test")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		storeDir := filepath.Join(testDir, "reopen-non-empty-store")
-		defer os.RemoveAll(storeDir)
 		require.NoError(t, fileops.CreateDir(storeDir))
 
 		c := &Config{
@@ -167,7 +146,6 @@ func TestOpen(t *testing.T) {
 			Logger:   logger,
 		}
 		s, err := Open(c)
-		defer os.RemoveAll(storeDir)
 		require.NoError(t, err)
 
 		// close and reopen the store

--- a/internal/mptrie/store/update_and_query_test.go
+++ b/internal/mptrie/store/update_and_query_test.go
@@ -2,8 +2,6 @@ package store
 
 import (
 	"encoding/binary"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -27,9 +25,7 @@ func TestPutAndPersist(t *testing.T) {
 	t.Run("only put", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "update_and_query_test")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		storeDir := filepath.Join(testDir, "test-store1")
 		c := &Config{
@@ -51,9 +47,7 @@ func TestPutAndPersist(t *testing.T) {
 	t.Run("put and persist", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "update_and_query_test")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		storeDir := filepath.Join(testDir, "test-store2")
 		c := &Config{
@@ -75,9 +69,7 @@ func TestPutAndPersist(t *testing.T) {
 	t.Run("put partial persist and clean memory", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "update_and_query_test")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		storeDir := filepath.Join(testDir, "test-store3")
 		c := &Config{
@@ -126,9 +118,7 @@ func TestPutAndPersist(t *testing.T) {
 	t.Run("put and persist - reopen store", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "update_and_query_test")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		storeDir := filepath.Join(testDir, "test-store4")
 		c := &Config{

--- a/internal/provenance/commit_and_query_test.go
+++ b/internal/provenance/commit_and_query_test.go
@@ -3,8 +3,6 @@
 package provenance
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/hyperledger-labs/orion-server/pkg/logger"
@@ -19,8 +17,7 @@ type testEnv struct {
 }
 
 func newTestEnv(t *testing.T) *testEnv {
-	storeDir, err := ioutil.TempDir("", "provenance")
-	require.NoError(t, err)
+	storeDir := t.TempDir()
 
 	lc := &logger.Config{
 		Level:         "debug",
@@ -38,10 +35,6 @@ func newTestEnv(t *testing.T) *testEnv {
 
 	store, err := Open(c)
 	if err != nil {
-		if rmErr := os.RemoveAll(storeDir); rmErr != nil {
-			t.Errorf("error while removing directory %s, %v", storeDir, rmErr)
-		}
-
 		t.Fatalf("error while opening store on path %s, %v", storeDir, err)
 	}
 
@@ -51,10 +44,6 @@ func newTestEnv(t *testing.T) *testEnv {
 		cleanup: func() {
 			if err := store.Close(); err != nil {
 				t.Errorf("error while closing the store %s, %v", storeDir, err)
-			}
-
-			if err := os.RemoveAll(storeDir); err != nil {
-				t.Fatalf("error while removing directory %s, %v", storeDir, err)
 			}
 		},
 	}

--- a/internal/provenance/open_test.go
+++ b/internal/provenance/open_test.go
@@ -5,8 +5,6 @@ package provenance
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path"
 	"path/filepath"
 	"testing"
@@ -44,9 +42,7 @@ func TestOpenStore(t *testing.T) {
 	t.Run("open a new store", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "opentest")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		storeDir := filepath.Join(testDir, "new-store")
 		c := &Config{
@@ -68,9 +64,7 @@ func TestOpenStore(t *testing.T) {
 	t.Run("open and reopen a disabled store", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "opentest")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		storeDir := filepath.Join(testDir, "new-store")
 		c := &Config{
@@ -99,9 +93,7 @@ func TestOpenStore(t *testing.T) {
 	t.Run("disable an active store", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "opentest")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		storeDir := filepath.Join(testDir, "new-store")
 		c := &Config{
@@ -130,9 +122,7 @@ func TestOpenStore(t *testing.T) {
 	t.Run("open while partial store exist with an empty dir", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "opentest")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		// create folders and files to mimic an existing creation but a crash before
 		// the successful completion
@@ -149,7 +139,6 @@ func TestOpenStore(t *testing.T) {
 				t.Errorf("error wile closing the store: %s", err.Error())
 			}
 		}()
-		defer os.RemoveAll(storeDir)
 		require.NoError(t, err)
 
 		assertStore(t, storeDir, s)
@@ -158,9 +147,7 @@ func TestOpenStore(t *testing.T) {
 	t.Run("open while partial store exist with a creation flag", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "opentest")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		// create folders and files to mimic an existing creation but a crash before
 		// the successful completion
@@ -187,7 +174,6 @@ func TestOpenStore(t *testing.T) {
 				t.Errorf("error wile closing the store: %s", err.Error())
 			}
 		}()
-		defer os.RemoveAll(storeDir)
 		require.NoError(t, err)
 
 		assertStore(t, storeDir, s)
@@ -197,9 +183,7 @@ func TestOpenStore(t *testing.T) {
 	t.Run("reopen an empty store", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "opentest")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		storeDir := filepath.Join(testDir, "reopen-empty-store")
 		require.NoError(t, fileops.CreateDir(storeDir))
@@ -209,7 +193,6 @@ func TestOpenStore(t *testing.T) {
 			Logger:   logger,
 		}
 		s, err := Open(c)
-		defer os.RemoveAll(storeDir)
 		require.NoError(t, err)
 		s.Close()
 
@@ -231,12 +214,9 @@ func TestOpenStore(t *testing.T) {
 	t.Run("reopen non-empty store", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "opentest")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		storeDir := filepath.Join(testDir, "reopen-non-empty-store")
-		defer os.RemoveAll(storeDir)
 		require.NoError(t, fileops.CreateDir(storeDir))
 
 		c := &Config{
@@ -244,7 +224,6 @@ func TestOpenStore(t *testing.T) {
 			Logger:   logger,
 		}
 		s, err := Open(c)
-		defer os.RemoveAll(storeDir)
 		require.NoError(t, err)
 
 		assertStore(t, storeDir, s)

--- a/internal/queryexecutor/executor_test.go
+++ b/internal/queryexecutor/executor_test.go
@@ -3,7 +3,6 @@ package queryexecutor
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -35,20 +34,11 @@ func newTestEnv(t *testing.T) *testEnv {
 	)
 	require.NoError(t, err)
 
-	tempDir, err := ioutil.TempDir("/tmp", "queryexecutor")
-	require.NoError(t, err)
+	tempDir := t.TempDir()
 	db, err := leveldb.Open(
 		&leveldb.Config{
 			DBRootDir: tempDir,
 			Logger:    l,
-		},
-	)
-	t.Cleanup(
-		func() {
-			if err := os.RemoveAll(tempDir); err != nil {
-				t.Log("error during cleanup: removal of directory [" + tempDir + "] failed with error [" + err.Error() + "]")
-				t.Fail()
-			}
 		},
 	)
 	require.NoError(t, err)
@@ -59,10 +49,6 @@ func newTestEnv(t *testing.T) *testEnv {
 		cleanup: func() {
 			if err := db.Close(); err != nil {
 				t.Log("error while closing the database: [" + err.Error() + "]")
-			}
-			if err := os.RemoveAll(tempDir); err != nil {
-				t.Log("error during cleanup: removal of directory [" + tempDir + "] failed with error [" + err.Error() + "]")
-				t.Fail()
 			}
 		},
 	}

--- a/internal/replication/blockreplicator_test.go
+++ b/internal/replication/blockreplicator_test.go
@@ -4,8 +4,6 @@
 package replication_test
 
 import (
-	"io/ioutil"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -24,7 +22,6 @@ import (
 func TestBlockReplicator_StartClose_Fast(t *testing.T) {
 	env := createNodeEnv(t, "info")
 	require.NotNil(t, env)
-	defer os.RemoveAll(env.testDir)
 
 	err := env.conf.Transport.Start()
 	require.NoError(t, err)
@@ -46,7 +43,6 @@ func TestBlockReplicator_StartClose_Fast(t *testing.T) {
 func TestBlockReplicator_StartClose_Slow(t *testing.T) {
 	env := createNodeEnv(t, "info")
 	require.NotNil(t, env)
-	defer os.RemoveAll(env.testDir)
 
 	err := env.conf.Transport.Start()
 	require.NoError(t, err)
@@ -75,7 +71,6 @@ func TestBlockReplicator_StartClose_Slow(t *testing.T) {
 func TestBlockReplicator_Restart(t *testing.T) {
 	env := createNodeEnv(t, "info")
 	require.NotNil(t, env)
-	defer os.RemoveAll(env.testDir)
 
 	err := env.conf.Transport.Start()
 	require.NoError(t, err)
@@ -122,7 +117,6 @@ func TestBlockReplicator_Submit(t *testing.T) {
 	t.Run("normal flow", func(t *testing.T) {
 		env := createNodeEnv(t, "info")
 		require.NotNil(t, env)
-		defer os.RemoveAll(env.testDir)
 
 		err := env.conf.Transport.Start()
 		require.NoError(t, err)
@@ -183,7 +177,6 @@ func TestBlockReplicator_Submit(t *testing.T) {
 	t.Run("normal flow: close before commit reply", func(t *testing.T) {
 		env := createNodeEnv(t, "info")
 		require.NotNil(t, env)
-		defer os.RemoveAll(env.testDir)
 
 		err := env.conf.Transport.Start()
 		require.NoError(t, err)
@@ -219,7 +212,6 @@ func TestBlockReplicator_Submit(t *testing.T) {
 	t.Run("normal flow: blocked submit", func(t *testing.T) {
 		env := createNodeEnv(t, "info")
 		require.NotNil(t, env)
-		defer os.RemoveAll(env.testDir)
 
 		err := env.conf.Transport.Start()
 		require.NoError(t, err)
@@ -284,7 +276,6 @@ func TestBlockReplicator_Submit(t *testing.T) {
 	t.Run("restart", func(t *testing.T) {
 		env := createNodeEnv(t, "info")
 		require.NotNil(t, env)
-		defer os.RemoveAll(env.testDir)
 
 		err := env.conf.Transport.Start()
 		require.NoError(t, err)
@@ -385,7 +376,6 @@ func TestBlockReplicator_ReConfig(t *testing.T) {
 	t.Run("update admins", func(t *testing.T) {
 		env := createNodeEnv(t, "info")
 		require.NotNil(t, env)
-		defer os.RemoveAll(env.testDir)
 		err := env.Start()
 		require.NoError(t, err)
 
@@ -435,7 +425,6 @@ func TestBlockReplicator_ReConfig(t *testing.T) {
 	t.Run("update CAs", func(t *testing.T) {
 		env := createNodeEnv(t, "info")
 		require.NotNil(t, env)
-		defer os.RemoveAll(env.testDir)
 		err := env.Start()
 		require.NoError(t, err)
 
@@ -487,9 +476,7 @@ func TestBlockReplicator_Snapshots(t *testing.T) {
 	// - submit blocks and verify the last 4 snapshots exist.
 	t.Run("take a snapshot every two blocks", func(t *testing.T) {
 		lg := testLogger(t, "info")
-		testDir, err := ioutil.TempDir("", "replication-test")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		block := &types.Block{
 			Header: &types.BlockHeader{
@@ -555,9 +542,7 @@ func TestBlockReplicator_Snapshots(t *testing.T) {
 	// Correct behavior after restart is checked by submitting more blocks and checking that they commit.
 	t.Run("restart from a snapshot", func(t *testing.T) {
 		lg := testLogger(t, "info")
-		testDir, err := ioutil.TempDir("", "replication-test")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		block := &types.Block{
 			Header: &types.BlockHeader{

--- a/internal/replication/env_test.go
+++ b/internal/replication/env_test.go
@@ -2,9 +2,7 @@ package replication_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math"
-	"os"
 	"path"
 	"reflect"
 	"sync"
@@ -74,12 +72,10 @@ type nodeEnv struct {
 
 func createNodeEnv(t *testing.T, level string) *nodeEnv {
 	lg := testLogger(t, level)
-	testDir, err := ioutil.TempDir("", "replication-test")
-	require.NoError(t, err)
+	testDir := t.TempDir()
 
 	env, err := newNodeEnv(1, testDir, lg, clusterConfig1node)
 	if err != nil {
-		os.RemoveAll(testDir)
 		return nil
 	}
 	env.testDir = testDir // clean the top level
@@ -207,8 +203,7 @@ type clusterEnv struct {
 func createClusterEnv(t *testing.T, nNodes int, raftConf *types.RaftConfig, logLevel string, logOpts ...zap.Option) *clusterEnv {
 	lg := testLogger(t, logLevel, logOpts...)
 
-	testDir, err := ioutil.TempDir("", "replication-test")
-	require.NoError(t, err)
+	testDir := t.TempDir()
 
 	clusterConfig := &types.ClusterConfig{
 		ConsensusConfig: &types.ConsensusConfig{
@@ -249,7 +244,6 @@ func createClusterEnv(t *testing.T, nNodes int, raftConf *types.RaftConfig, logL
 	for n := uint32(1); n <= uint32(nNodes); n++ {
 		nEnv, err := newNodeEnv(n, testDir, lg, proto.Clone(clusterConfig).(*types.ClusterConfig))
 		if err != nil {
-			os.RemoveAll(testDir)
 			return nil
 		}
 
@@ -266,9 +260,6 @@ func destroyClusterEnv(t *testing.T, env *clusterEnv) {
 			assert.NoError(t, err)
 		}
 	}
-
-	err := os.RemoveAll(env.testDir)
-	assert.NoError(t, err)
 }
 
 // create a BlockReplicator environment with a genesis block

--- a/internal/replication/storage_test.go
+++ b/internal/replication/storage_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package replication
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -44,8 +43,7 @@ func setup(t *testing.T) {
 	require.NoError(t, err)
 
 	ram = raft.NewMemoryStorage()
-	dataDir, err = ioutil.TempDir("", "etcdraft-")
-	require.NoError(t, err)
+	dataDir = t.TempDir()
 	walDir, snapDir = path.Join(dataDir, "wal"), path.Join(dataDir, "snapshot")
 	store, err = CreateStorage(lg, walDir, snapDir)
 	require.NoError(t, err)
@@ -53,8 +51,6 @@ func setup(t *testing.T) {
 
 func clean(t *testing.T) {
 	err = store.Close()
-	require.NoError(t, err)
-	err = os.RemoveAll(dataDir)
 	require.NoError(t, err)
 }
 

--- a/internal/stateindex/index_entries_test.go
+++ b/internal/stateindex/index_entries_test.go
@@ -5,9 +5,7 @@ package stateindex
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"math"
-	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -35,8 +33,7 @@ func newIndexTestEnv(t *testing.T) *indexTestEnv {
 	logger, err := logger.New(lc)
 	require.NoError(t, err)
 
-	dir, err := ioutil.TempDir("", "index")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	dbPath := filepath.Join(dir, "leveldb")
 	db, err := leveldb.Open(
@@ -46,9 +43,6 @@ func newIndexTestEnv(t *testing.T) *indexTestEnv {
 		},
 	)
 	if err != nil {
-		if rmErr := os.RemoveAll(dir); rmErr != nil {
-			t.Errorf("error while removing directory %s, %v", dir, rmErr)
-		}
 		t.Fatalf("error while creating leveldb, %v", err)
 	}
 

--- a/internal/txvalidation/validator_test.go
+++ b/internal/txvalidation/validator_test.go
@@ -4,8 +4,6 @@
 package txvalidation
 
 import (
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -37,8 +35,7 @@ func newValidatorTestEnv(t *testing.T) *validatorTestEnv {
 	logger, err := logger.New(c)
 	require.NoError(t, err)
 
-	dir, err := ioutil.TempDir("/tmp", "validator")
-	require.NoError(t, err)
+	dir := t.TempDir()
 	path := filepath.Join(dir, "leveldb")
 
 	db, err := leveldb.Open(
@@ -48,18 +45,12 @@ func newValidatorTestEnv(t *testing.T) *validatorTestEnv {
 		},
 	)
 	if err != nil {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Errorf("failed to remove directory %s, %v", dir, err)
-		}
 		t.Fatalf("failed to create leveldb with path %s", path)
 	}
 
 	cleanup := func() {
 		if err := db.Close(); err != nil {
 			t.Errorf("failed to close the db instance, %v", err)
-		}
-		if err := os.RemoveAll(dir); err != nil {
-			t.Errorf("failed to remove directory %s, %v", dir, err)
 		}
 	}
 

--- a/internal/worldstate/leveldb/commit_and_query_test.go
+++ b/internal/worldstate/leveldb/commit_and_query_test.go
@@ -4,16 +4,14 @@
 package leveldb
 
 import (
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger-labs/orion-server/internal/fileops"
 	"github.com/hyperledger-labs/orion-server/internal/worldstate"
 	"github.com/hyperledger-labs/orion-server/pkg/logger"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
-	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/require"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 )
@@ -25,8 +23,7 @@ type testEnv struct {
 }
 
 func newTestEnv(t *testing.T) *testEnv {
-	dir, err := ioutil.TempDir("/tmp", "ledger")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	path := filepath.Join(dir, "leveldb")
 
@@ -45,19 +42,12 @@ func newTestEnv(t *testing.T) *testEnv {
 	}
 	l, err := Open(conf)
 	if err != nil {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Errorf("failed to remove %s, %v", dir, err)
-		}
 		t.Fatalf("failed to create leveldb with path %s", path)
 	}
 
 	cleanup := func() {
 		if err := l.Close(); err != nil {
 			t.Errorf("failed to close the database instance, %v", err)
-		}
-
-		if err := os.RemoveAll(dir); err != nil {
-			t.Errorf("failed to remove %s, %v", dir, err)
 		}
 	}
 

--- a/internal/worldstate/leveldb/open_test.go
+++ b/internal/worldstate/leveldb/open_test.go
@@ -3,8 +3,6 @@
 package leveldb
 
 import (
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -39,9 +37,7 @@ func TestOpenLevelDBInstance(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("open a new levelDB instance", func(t *testing.T) {
-		testDir, err := ioutil.TempDir("", "opentest")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		dbRootDir := filepath.Join(testDir, "new-leveldb")
 		conf := &Config{
@@ -60,9 +56,7 @@ func TestOpenLevelDBInstance(t *testing.T) {
 	t.Run("open while partial leveldb instance exist with an empty dir", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "opentest")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		// create folders and files to mimic an existing creation but a crash before
 		// the successful completion
@@ -85,9 +79,7 @@ func TestOpenLevelDBInstance(t *testing.T) {
 	t.Run("open while partial leveldb instance exist with the creation flag", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "opentest")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		// create folders and files to mimic an existing creation but a crash before
 		// the successful completion
@@ -113,9 +105,7 @@ func TestOpenLevelDBInstance(t *testing.T) {
 	t.Run("reopen an empty leveldb", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "opentest")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		dbRootDir := filepath.Join(testDir, "reopen-empty-store")
 		conf := &Config{
@@ -141,9 +131,7 @@ func TestOpenLevelDBInstance(t *testing.T) {
 	t.Run("reopen non-empty leveldb", func(t *testing.T) {
 		t.Parallel()
 
-		testDir, err := ioutil.TempDir("", "opentest")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		dbRootDir := filepath.Join(testDir, "reopen-non-empty-store")
 		conf := &Config{

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -95,9 +95,7 @@ func TestLogger(t *testing.T) {
 		t.Run(tt.level, func(t *testing.T) {
 			t.Parallel()
 
-			testDir, err := ioutil.TempDir("", "logger-test")
-			require.NoError(t, err)
-			defer os.RemoveAll(testDir)
+			testDir := t.TempDir()
 
 			logFile := path.Join(testDir, tt.fileName)
 
@@ -191,9 +189,7 @@ func TestDynamicLogger(t *testing.T) {
 		t.Run(tt.level, func(t *testing.T) {
 			t.Parallel()
 
-			testDir, err := ioutil.TempDir("", "logger-test")
-			require.NoError(t, err)
-			defer os.RemoveAll(testDir)
+			testDir := t.TempDir()
 
 			logFile := path.Join(testDir, tt.fileName)
 
@@ -393,9 +389,7 @@ func TestLoggerWith(t *testing.T) {
 		t.Run(tt.level, func(t *testing.T) {
 			t.Parallel()
 
-			testDir, err := ioutil.TempDir("", "logger-test")
-			require.NoError(t, err)
-			defer os.RemoveAll(testDir)
+			testDir := t.TempDir()
 
 			logFile := path.Join(testDir, tt.fileName)
 			l, err := New(&Config{

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/tls"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"net/url"
@@ -136,13 +135,7 @@ func (env *serverTestEnv) getConfigResponse(t *testing.T) *types.GetConfigRespon
 }
 
 func newServerTestEnv(t *testing.T, serverTLS bool, clientTLS bool, disableProvenance bool) *serverTestEnv {
-	tempDir, err := ioutil.TempDir("/tmp", "serverTest")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			t.Errorf("error while removing test directory: %v", err)
-		}
-	})
+	tempDir := t.TempDir()
 
 	rootCAPemCert, caPrivKey, err := testutils.GenerateRootCA("Orion RootCA", "127.0.0.1")
 	require.NoError(t, err)

--- a/test/cluster/add_node_test.go
+++ b/test/cluster/add_node_test.go
@@ -95,8 +95,7 @@ func addServerTx(t *testing.T, c *setup.Cluster, setupConfig *setup.Config, conf
 // - add a new server (node-4)
 // - start the new server
 func TestBasicAddServer(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(4)
 	setupConfig := &setup.Config{
@@ -157,8 +156,7 @@ func TestBasicAddServer(t *testing.T) {
 // - Start a 1 node cluster
 // - add 2 new servers
 func TestAddFrom1To3(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(3)
 	setupConfig := &setup.Config{
@@ -255,14 +253,13 @@ func TestAddFrom1To3(t *testing.T) {
 // Scenario:
 // - Start a 3 node cluster
 // - failed to submit transactions:
-// 	  1. add 2 nodes in one tx
-// 	  2. add node to Members only without also adding to Nodes
-// 	  3. add node with invalid port
-// 	  4. add node with invalid cert
-// 	  5. add node with invalid raft-id
+//  1. add 2 nodes in one tx
+//  2. add node to Members only without also adding to Nodes
+//  3. add node with invalid port
+//  4. add node with invalid cert
+//  5. add node with invalid raft-id
 func TestInvalidAdd(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(3)
 	setupConfig := &setup.Config{
@@ -394,8 +391,7 @@ func TestInvalidAdd(t *testing.T) {
 // - restart nodes 5,6
 // - start node 7
 func TestAddAndRemove(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(3)
 	setupConfig := &setup.Config{

--- a/test/cluster/basic_test.go
+++ b/test/cluster/basic_test.go
@@ -5,7 +5,6 @@ package cluster
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"sync"
@@ -47,8 +46,7 @@ func getPorts(num uint32) (node uint32, peer uint32) {
 // - expect 1 tx to be accepted, and 2 to be redirected.
 // - check that the tx accepted is committed and that the written key-value is replicated to all servers.
 func TestBasicCluster(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(3)
 	setupConfig := &setup.Config{
@@ -113,8 +111,7 @@ func TestBasicCluster(t *testing.T) {
 // - wait for one to be the new leader.
 // - make sure the stopped server is in sync with the transaction made while it was stopped.
 func NodeRecovery(t *testing.T, victimIsLeader bool) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(3)
 	setupConfig := &setup.Config{
@@ -213,7 +210,7 @@ func TestNodeRecoveryLeader(t *testing.T) {
 	NodeRecovery(t, true)
 }
 
-//Scenario:
+// Scenario:
 // round 1:
 // - start 3 servers in a cluster.
 // - wait for one to be the leader.
@@ -233,8 +230,7 @@ func TestNodeRecoveryLeader(t *testing.T) {
 // - find leader4.
 // - submit a tx => tx accepted.
 func StopServerNoMajorityToChooseLeader(t *testing.T, victimIsLeader bool) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(3)
 	setupConfig := &setup.Config{
@@ -406,8 +402,7 @@ func TestStopLeaderNoMajorityToChooseLeader(t *testing.T) {
 // - shutting down and starting all servers in the cluster.
 // - make sure the servers are in sync with the txs made before they were shut down.
 func TestClusterRestart(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(3)
 	setupConfig := &setup.Config{
@@ -486,8 +481,7 @@ func TestClusterRestart(t *testing.T) {
 // - repeat until each server was a leader at least once.
 // - make sure each node submitted a valid tx as a leader.
 func TestAllNodesGetLeadership(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(3)
 	setupConfig := &setup.Config{

--- a/test/cluster/catchup_test.go
+++ b/test/cluster/catchup_test.go
@@ -4,7 +4,6 @@
 package cluster
 
 import (
-	"io/ioutil"
 	"net/http"
 	"path/filepath"
 	"strconv"
@@ -35,8 +34,7 @@ func createKeys(k int) []int {
 // - restart the server.
 // - make sure the server is in sync with previous txs.
 func NodeRecoveryWithCatchup(t *testing.T, victimIsLeader bool) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(3)
 	setupConfig := &setup.Config{
@@ -195,7 +193,7 @@ func TestLeaderRecoveryWithCatchup(t *testing.T) {
 	NodeRecoveryWithCatchup(t, true)
 }
 
-//Scenario:
+// Scenario:
 // round 1:
 // - start 3 servers in a cluster and change SnapshotIntervalSize to 4K.
 // - wait for one to be the leader.
@@ -215,8 +213,7 @@ func TestLeaderRecoveryWithCatchup(t *testing.T) {
 // - find leader4.
 // - submit a tx => tx accepted.
 func StopServerNoMajorityToChooseLeaderWithCatchup(t *testing.T, victimIsLeader bool) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(3)
 	setupConfig := &setup.Config{

--- a/test/cluster/cluster_redirection_test.go
+++ b/test/cluster/cluster_redirection_test.go
@@ -4,7 +4,6 @@
 package cluster
 
 import (
-	"io/ioutil"
 	"strconv"
 	"testing"
 	"time"
@@ -20,8 +19,7 @@ import (
 // - Submit txs to all nodes
 // - Tx redirection from follower to leader
 func TestRedirection(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{

--- a/test/cluster/config_admin_test.go
+++ b/test/cluster/config_admin_test.go
@@ -5,7 +5,6 @@ package cluster
 
 import (
 	"encoding/pem"
-	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
@@ -21,8 +20,7 @@ import (
 // - alice adds bob to the admins' list
 // - bob tries to add alice again to the admins' list => the tx fails because alice is already an admin
 func TestAddNewAdmins(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{
@@ -129,8 +127,7 @@ func TestAddNewAdmins(t *testing.T) {
 }
 
 func TestAddNewAdminWithInvalidCertificate(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{
@@ -182,8 +179,7 @@ func TestAddNewAdminWithInvalidCertificate(t *testing.T) {
 // - admin adds alice to admins list
 // - alice deletes admin from the admins' list
 func TestDeleteAdmin(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{
@@ -295,8 +291,7 @@ func TestDeleteAdmin(t *testing.T) {
 // - update admin signer to new signer based on alice's private key
 // - get config envelope
 func TestChangeAdminCA(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{
@@ -368,8 +363,7 @@ func TestChangeAdminCA(t *testing.T) {
 // - alice is a regular user so access to ClusterConfig is denied
 // - adding alice to admins list => alice can get ClusterConfig
 func TestGetClusterConfigAccessibility(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{

--- a/test/cluster/config_ca_test.go
+++ b/test/cluster/config_ca_test.go
@@ -6,7 +6,6 @@ package cluster
 import (
 	"crypto/tls"
 	"encoding/pem"
-	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
@@ -21,8 +20,7 @@ import (
 // Scenario:
 // - add Root CA & Intermediate CA to CertAuthConfig
 func TestAddCA(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{
@@ -180,8 +178,7 @@ func TestAddCA(t *testing.T) {
 // Scenario:
 // - adding an intermediate CA without adding the root it came from in the same tx (broken chain)
 func TestInvalidCABrokenChain(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{
@@ -243,8 +240,7 @@ func TestInvalidCABrokenChain(t *testing.T) {
 // - add a root CA as an intermediate CA
 // - update to empty CA
 func TestInvalidCAs(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{
@@ -339,8 +335,7 @@ func TestInvalidCAs(t *testing.T) {
 // - add Root CA & Intermediate CA to CertAuthConfig
 // - try to remove the original CA - tx fails
 func TestRemoveCA(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{

--- a/test/cluster/config_raft_test.go
+++ b/test/cluster/config_raft_test.go
@@ -4,11 +4,11 @@
 package cluster
 
 import (
-	"github.com/hyperledger-labs/orion-server/pkg/types"
-	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/hyperledger-labs/orion-server/pkg/types"
 
 	"github.com/hyperledger-labs/orion-server/test/setup"
 	"github.com/pkg/errors"
@@ -19,8 +19,7 @@ import (
 // - change the ticks, heartbeat interval, and election timeout (200ms, 4, 40)
 // - stop the leader and make sure a new leader is elected.
 func TestUpdateRaft(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(3)
 	setupConfig := &setup.Config{

--- a/test/cluster/remove_node_test.go
+++ b/test/cluster/remove_node_test.go
@@ -1,7 +1,6 @@
 package cluster
 
 import (
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"testing"
@@ -103,8 +102,7 @@ func removeServer(t *testing.T, leaderServer *setup.Server, c *setup.Cluster, re
 // - remove leader
 // - remove follower
 func TestRemoveLeaderAndFollower(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(3)
 	setupConfig := &setup.Config{
@@ -155,8 +153,7 @@ func TestRemoveLeaderAndFollower(t *testing.T) {
 // - start 2 => 3 nodes are active => there is a majority to choose a leader
 // - start 3
 func TestRemoveNodeLossOfQuorum(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(5)
 	setupConfig := &setup.Config{
@@ -223,8 +220,7 @@ func TestRemoveNodeLossOfQuorum(t *testing.T) {
 // - try to remove node from Members only without also removing from Nodes
 // - try to remove 2 servers in one tx
 func TestInvalidRemove(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(5)
 	setupConfig := &setup.Config{

--- a/test/cluster/security_test.go
+++ b/test/cluster/security_test.go
@@ -30,8 +30,7 @@ import (
 // - wait for one to be the new leader.
 // - make sure the stopped server is in sync with the txs made while it was stopped.
 func TestNodeRecoveryWithTLS(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(3)
 	setupConfig := &setup.Config{
@@ -107,8 +106,7 @@ func TestNodeRecoveryWithTLS(t *testing.T) {
 // - restart the server.
 // - make sure the server is in sync with previous txs.
 func TestNodeRecoveryWithCatchupAndTLS(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(3)
 	setupConfig := &setup.Config{
@@ -257,8 +255,7 @@ func TestNodeRecoveryWithCatchupAndTLS(t *testing.T) {
 // - create server with TLS disabled, fail to start the new server.
 // - create server with TLS enabled but a key-cert pair not from the cluster's CA, fail to start the new server.
 func TestTLSAddInvalidNodes(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(3)
 	setupConfig := &setup.Config{
@@ -362,8 +359,7 @@ func TestTLSAddInvalidNodes(t *testing.T) {
 // - start a 3 servers cluster with TLS enabled.
 // - change server-2 config file.
 func TestTLSChangeNodeCA(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(3)
 	setupConfig := &setup.Config{

--- a/test/data/data_tx_test.go
+++ b/test/data/data_tx_test.go
@@ -6,7 +6,6 @@ package datatxtest
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"strconv"
 	"sync"
 	"testing"
@@ -43,8 +42,7 @@ func getPorts(num uint32) (node uint32, peer uint32) {
 }
 
 func TestDataTx(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{
@@ -677,8 +675,7 @@ func TestDataTx(t *testing.T) {
 }
 
 func TestAsyncDataTx(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{

--- a/test/db/db_index_management_test.go
+++ b/test/db/db_index_management_test.go
@@ -5,7 +5,6 @@ package user
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"sync"
 	"testing"
 	"time"
@@ -41,8 +40,7 @@ func getPorts(num uint32) (node uint32, peer uint32) {
 
 // Scenario:
 func TestDBManagement(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{

--- a/test/queries/json_queries_test.go
+++ b/test/queries/json_queries_test.go
@@ -4,8 +4,6 @@
 package queries
 
 import (
-	"io/ioutil"
-	"os"
 	"sort"
 	"testing"
 	"time"
@@ -19,8 +17,7 @@ import (
 )
 
 func TestJSONQueries(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{
@@ -31,7 +28,6 @@ func TestJSONQueries(t *testing.T) {
 		BaseNodePort:        nPort,
 		BasePeerPort:        pPort,
 	}
-	defer os.RemoveAll(dir)
 	c, err := setup.NewCluster(setupConfig)
 	require.NoError(t, err)
 	defer c.ShutdownAndCleanup()

--- a/test/queries/ledger_test.go
+++ b/test/queries/ledger_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"strconv"
 	"testing"
 	"time"
@@ -33,8 +32,7 @@ import (
 // GET /ledger/block/{blockNumber}?augmented=true
 // where {blockNumber} is 1 (genesis), 2-11 (data)
 func TestLedgerBlockQueries(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{
@@ -205,8 +203,7 @@ func TestLedgerBlockQueries(t *testing.T) {
 // HTTP GET "/ledger/path?start={startId}&end={endId}" with invalid query params
 // where {startId} and {endId} are: out of range, reverse order
 func TestLedgerPathQueries(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{
@@ -392,8 +389,7 @@ func verifyLedgerPath(lp []*types.BlockHeader) error {
 // HTTP GET "/ledger/proof/tx/{blockId}?idx={idx}" gets proof for tx with index idx inside block blockId
 // HTTP GET "/ledger/proof/tx/{blockId}?idx={idx}" with invalid query params
 func TestLedgerTxProof(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{
@@ -471,8 +467,7 @@ func TestLedgerTxProof(t *testing.T) {
 // HTTP GET "/ledger/proof/tx/{blockId}?idx={idx}" gets proof for tx with index idx inside block blockId
 // HTTP GET "/ledger/proof/tx/{blockId}?idx={idx}" with invalid query params
 func TestLedgerAsyncTxProof(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{
@@ -643,8 +638,7 @@ func verifyTxProof(intermediateHashes [][]byte, receipt *types.TxReceipt, tx pro
 // HTTP GET "/ledger/proof/data/{blockId}/{dbname}/{key}?deleted={true|false}" gets proof for value associated with (dbname, key) in block blockId,
 // HTTP GET "/ledger/proof/data/{blockId}/{dbname}/{key}" gets proof for value associated with (dbname, key) in block blockId
 func TestLedgerDataProof(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{
@@ -757,8 +751,7 @@ func TestLedgerDataProof(t *testing.T) {
 }
 
 func TestLedgerAsyncDataProof(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{
@@ -955,8 +948,7 @@ func calculateValueHash(dbName, key string, value []byte) ([]byte, error) {
 }
 
 func TestLedgerAsyncDataMPTrieDisabled(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{

--- a/test/queries/provenance_acl_test.go
+++ b/test/queries/provenance_acl_test.go
@@ -4,7 +4,6 @@
 package queries
 
 import (
-	"io/ioutil"
 	"testing"
 	"time"
 
@@ -18,8 +17,7 @@ import (
 // only the admin user can read historical data.
 // only the user and admin can fetch all operations performed by the user.
 func TestProvenanceACL(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{

--- a/test/queries/provenance_switch_off_test.go
+++ b/test/queries/provenance_switch_off_test.go
@@ -5,7 +5,6 @@ package queries
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
@@ -24,8 +23,7 @@ import (
 // - switching provenance off in server-0 that had it on is supported.
 // - trying to restart server-0 with provenance on fails.
 func TestProvenanceSwitchOff(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(3)
 	setupConfig := &setup.Config{

--- a/test/queries/provenance_test.go
+++ b/test/queries/provenance_test.go
@@ -4,7 +4,6 @@
 package queries
 
 import (
-	"io/ioutil"
 	"sort"
 	"testing"
 	"time"
@@ -18,8 +17,7 @@ import (
 )
 
 func TestProvenanceQueries(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{
@@ -30,7 +28,6 @@ func TestProvenanceQueries(t *testing.T) {
 		BaseNodePort:        nPort,
 		BasePeerPort:        pPort,
 	}
-	// defer os.RemoveAll(dir)
 	c, err := setup.NewCluster(setupConfig)
 	require.NoError(t, err)
 	defer c.ShutdownAndCleanup()

--- a/test/queries/range_query_test.go
+++ b/test/queries/range_query_test.go
@@ -5,9 +5,7 @@ package queries
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math"
-	"os"
 	"testing"
 	"time"
 
@@ -22,11 +20,10 @@ import (
 // - Execute queries with and without pagination triggered by user limit
 // - Execute open intervals queries
 // - Execute queries that returns empty response:
-//// - the start key is after the end key in alphabetical order
-//// - key that does not exist in the database
+// // - the start key is after the end key in alphabetical order
+// // - key that does not exist in the database
 func TestRangeQueriesWithUserLimit(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{
@@ -38,7 +35,6 @@ func TestRangeQueriesWithUserLimit(t *testing.T) {
 		BasePeerPort:        pPort,
 		ServersQueryLimit:   math.MaxInt64,
 	}
-	defer os.RemoveAll(dir)
 	c, err := setup.NewCluster(setupConfig)
 	require.NoError(t, err)
 	defer c.ShutdownAndCleanup()
@@ -110,11 +106,10 @@ func TestRangeQueriesWithUserLimit(t *testing.T) {
 // - Execute queries with and without pagination triggered by server limit
 // - Execute open intervals queries
 // - Execute queries that returns empty response:
-//// - the start key is after the end key in alphabetical order
-//// - key that does not exist in the database
+// // - the start key is after the end key in alphabetical order
+// // - key that does not exist in the database
 func TestRangeQueriesWithServerLimit(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{
@@ -184,8 +179,7 @@ func TestRangeQueriesWithServerLimit(t *testing.T) {
 // - create cluster with QueryLimit = 10
 // - Try to execute a query that returns a response size larger than the limit
 func TestInvalidRangeQuery(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{

--- a/test/setup/cluster_setup_test.go
+++ b/test/setup/cluster_setup_test.go
@@ -5,7 +5,6 @@ package setup_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"testing"
 	"time"
 
@@ -16,8 +15,7 @@ import (
 )
 
 func TestClusterSetup(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 	setupConfig := &setup.Config{
 		NumberOfServers:     3,
 		TestDirAbsolutePath: dir,

--- a/test/setup/config_writer_test.go
+++ b/test/setup/config_writer_test.go
@@ -4,8 +4,6 @@
 package setup
 
 import (
-	"io/ioutil"
-	"os"
 	"path"
 	"testing"
 
@@ -16,9 +14,7 @@ import (
 )
 
 func TestWriteLocalConfig(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "integration-test-setup-")
-	require.NoError(t, err)
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	localConfig := &config.LocalConfiguration{
 		Server: config.ServerConf{
@@ -59,7 +55,7 @@ func TestWriteLocalConfig(t *testing.T) {
 
 	fileName := path.Join(testDir, "config.yml")
 
-	err = WriteLocalConfig(localConfig, fileName)
+	err := WriteLocalConfig(localConfig, fileName)
 	require.NoError(t, err)
 
 	v := viper.New()
@@ -73,9 +69,7 @@ func TestWriteLocalConfig(t *testing.T) {
 }
 
 func TestWriteSharedConfig(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "integration-test-setup-")
-	require.NoError(t, err)
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	sharedConfig := &config.SharedConfiguration{
 		Nodes: []*config.NodeConf{
@@ -106,7 +100,7 @@ func TestWriteSharedConfig(t *testing.T) {
 
 	fileName := path.Join(testDir, "shared-config.yml")
 
-	err = WriteSharedConfig(sharedConfig, fileName)
+	err := WriteSharedConfig(sharedConfig, fileName)
 	require.NoError(t, err)
 
 	v := viper.New()

--- a/test/user/user_db_acl_test.go
+++ b/test/user/user_db_acl_test.go
@@ -4,7 +4,6 @@
 package user
 
 import (
-	"io/ioutil"
 	"sync"
 	"testing"
 	"time"
@@ -39,8 +38,7 @@ func getPorts(num uint32) (node uint32, peer uint32) {
 }
 
 func TestUserACLOnDatabase(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{
@@ -206,8 +204,7 @@ func TestUserACLOnDatabase(t *testing.T) {
 
 // Scenario:
 func TestUserCertificateUpdate(t *testing.T) {
-	dir, err := ioutil.TempDir("", "update-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{

--- a/test/user/user_error_cases_test.go
+++ b/test/user/user_error_cases_test.go
@@ -1,7 +1,6 @@
 package user
 
 import (
-	"io/ioutil"
 	"testing"
 	"time"
 
@@ -14,8 +13,7 @@ import (
 )
 
 func TestUserTxErrorCases(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{

--- a/test/user/user_update_acl_test.go
+++ b/test/user/user_update_acl_test.go
@@ -1,7 +1,6 @@
 package user
 
 import (
-	"io/ioutil"
 	"testing"
 	"time"
 
@@ -12,8 +11,7 @@ import (
 )
 
 func TestUserUpdateACL(t *testing.T) {
-	dir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	nPort, pPort := getPorts(1)
 	setupConfig := &setup.Config{


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	require.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```