### PR TITLE
Cache LevelDB snapshots and use lock-free map

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20210226220824-aa7126864d82 // indirect git tag v3.4.15
+	go.uber.org/multierr v1.6.0
 	go.uber.org/zap v1.18.1
 	google.golang.org/protobuf v1.26.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/internal/worldstate/leveldb/cache.go
+++ b/internal/worldstate/leveldb/cache.go
@@ -2,8 +2,6 @@ package leveldb
 
 import (
 	"github.com/VictoriaMetrics/fastcache"
-	"github.com/golang/protobuf/proto"
-	"github.com/hyperledger-labs/orion-server/pkg/types"
 )
 
 var keySep = []byte{0x00}
@@ -27,19 +25,9 @@ func newCache(dataCacheSizeMBs int) *cache {
 
 // getState returns the value for a given namespace and key from
 // the cache
-func (c *cache) getState(namespace, key string) (*types.ValueWithMetadata, error) {
+func (c *cache) getState(namespace, key string) ([]byte, bool) {
 	cacheKey := constructCacheKey(namespace, key)
-
-	valBytes, exists := c.dataCache.HasGet(nil, cacheKey)
-	if !exists {
-		return nil, nil
-	}
-
-	cacheValue := &types.ValueWithMetadata{}
-	if err := proto.Unmarshal(valBytes, cacheValue); err != nil {
-		return nil, err
-	}
-	return cacheValue, nil
+	return c.dataCache.HasGet(nil, cacheKey)
 }
 
 // putState stores a given value in the cache

--- a/internal/worldstate/leveldb/cache_test.go
+++ b/internal/worldstate/leveldb/cache_test.go
@@ -9,6 +9,17 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+func unmarshaler(t *testing.T) func(b []byte, inCache bool) (*types.ValueWithMetadata, bool) {
+	return func(b []byte, inCache bool) (*types.ValueWithMetadata, bool) {
+		if !inCache {
+			return nil, inCache
+		}
+		value := &types.ValueWithMetadata{}
+		require.NoError(t, proto.Unmarshal(b, value))
+		return value, inCache
+	}
+}
+
 func TestCache(t *testing.T) {
 	cache := newCache(10)
 
@@ -34,8 +45,8 @@ func TestCache(t *testing.T) {
 
 	t.Run("check basic storage and retrieval", func(t *testing.T) {
 		// db1, key1 does not exist
-		v, err := cache.getState("db1", "key1")
-		require.NoError(t, err)
+		v, inCache := cache.getState("db1", "key1")
+		require.False(t, inCache)
 		require.Nil(t, v)
 
 		s := &fastcache.Stats{}
@@ -54,11 +65,12 @@ func TestCache(t *testing.T) {
 		}
 		valBytes, err := proto.Marshal(db1Key1Value1)
 		require.NoError(t, err)
-		cache.putState("db1", "key1", valBytes)
+		require.NoError(t, cache.putState("db1", "key1", valBytes))
 
-		// db1, key1 should exists
-		actualKey1Value1, err := cache.getState("db1", "key1")
-		require.NoError(t, err)
+		// db1, key1 should exist
+		actualKey1Value1, inCache := unmarshaler(t)(cache.getState("db1", "key1"))
+		require.True(t, inCache)
+		require.NotNil(t, actualKey1Value1)
 		require.True(t, proto.Equal(db1Key1Value1, actualKey1Value1))
 
 		cache.dataCache.UpdateStats(s)
@@ -69,11 +81,12 @@ func TestCache(t *testing.T) {
 		// update key1's value
 		valBytes, err := proto.Marshal(db1Key1Value2)
 		require.NoError(t, err)
-		cache.putState("db1", "key1", valBytes)
+		require.NoError(t, cache.putState("db1", "key1", valBytes))
 
 		// db1, key1 should have the updated value
-		actualKey1Value2, err := cache.getState("db1", "key1")
-		require.NoError(t, err)
+		actualKey1Value2, inCache := unmarshaler(t)(cache.getState("db1", "key1"))
+		require.True(t, inCache)
+		require.NotNil(t, actualKey1Value2)
 		require.True(t, proto.Equal(db1Key1Value2, actualKey1Value2))
 
 		s := &fastcache.Stats{}
@@ -87,8 +100,8 @@ func TestCache(t *testing.T) {
 		require.NoError(t, err)
 		cache.putStateIfExist("db2", "key1", valBytes)
 
-		v, err := cache.getState("db2", "key1")
-		require.NoError(t, err)
+		v, inCache := unmarshaler(t)(cache.getState("db2", "key1"))
+		require.False(t, inCache)
 		require.Nil(t, v)
 
 		s := &fastcache.Stats{}
@@ -99,15 +112,17 @@ func TestCache(t *testing.T) {
 	t.Run("store same key in two different databases", func(t *testing.T) {
 		valBytes, err := proto.Marshal(db2Key1Value1)
 		require.NoError(t, err)
-		cache.putState("db2", "key1", valBytes)
+		require.NoError(t, cache.putState("db2", "key1", valBytes))
 
 		// both db1, key1 and db2, key1 should exist
-		actualDB1Key1Value2, err := cache.getState("db1", "key1")
-		require.NoError(t, err)
+		actualDB1Key1Value2, inCache := unmarshaler(t)(cache.getState("db1", "key1"))
+		require.True(t, inCache)
+		require.NotNil(t, actualDB1Key1Value2)
 		require.True(t, proto.Equal(db1Key1Value2, actualDB1Key1Value2))
 
-		actualDB2Key1Value1, err := cache.getState("db2", "key1")
-		require.NoError(t, err)
+		actualDB2Key1Value1, inCache := unmarshaler(t)(cache.getState("db2", "key1"))
+		require.True(t, inCache)
+		require.NotNil(t, actualDB2Key1Value1)
 		require.True(t, proto.Equal(db2Key1Value1, actualDB2Key1Value1))
 
 		s := &fastcache.Stats{}

--- a/internal/worldstate/leveldb/commit_and_query.go
+++ b/internal/worldstate/leveldb/commit_and_query.go
@@ -56,7 +56,7 @@ func (l *LevelDB) Height() (uint64, error) {
 		return 0, errors.Errorf("unable to retrieve the state database height due to missing metadataDB")
 	}
 
-	blockNumberEnc, err := db.reader.Get(lastCommittedBlockNumberKey, db.readOpts)
+	blockNumberEnc, err := db.file.Get(lastCommittedBlockNumberKey, db.readOpts)
 	if err != nil && err != leveldb.ErrNotFound {
 		return 0, errors.Wrap(err, "error while retrieving the state database height")
 	}
@@ -90,7 +90,7 @@ func (l *LevelDB) Get(dbName string, key string) ([]byte, *types.Metadata, error
 	dbVal, inCache := l.cache.getState(dbName, key)
 	if !inCache {
 		var err error
-		dbVal, err = db.reader.Get([]byte(key), db.readOpts)
+		dbVal, err = db.file.Get([]byte(key), db.readOpts)
 		switch err {
 		case leveldb.ErrNotFound:
 			if err = l.cache.putState(dbName, key, nil); err != nil {
@@ -144,7 +144,7 @@ func (l *LevelDB) Has(dbName, key string) (bool, error) {
 	if !ok || db == nil {
 		return false, &DBNotFoundErr{dbName: dbName}
 	}
-	has, err := db.reader.Has([]byte(key), db.readOpts)
+	has, err := db.file.Has([]byte(key), db.readOpts)
 	return has, convertClosedErr(err, dbName)
 }
 
@@ -191,7 +191,7 @@ func (l *LevelDB) GetIterator(dbName string, startKey, endKey string) (worldstat
 		r.Limit = []byte(endKey)
 	}
 
-	it := db.reader.NewIterator(r, &opt.ReadOptions{})
+	it := db.file.NewIterator(r, &opt.ReadOptions{})
 
 	// Iterator contains errors internally, but we want to fail early if there is an issue with the DB.
 	if err := convertClosedErr(it.Error(), dbName); err != nil {
@@ -214,9 +214,6 @@ func (l *LevelDB) Commit(dbsUpdates map[string]*worldstate.DBUpdates, blockNumbe
 		if err := l.commitToDB(db, updates); err != nil {
 			return err
 		}
-		if err := db.updateSnapshot(); err != nil {
-			return err
-		}
 		l.logger.Debugf("changes committed to the database %s, took %d ms, available dbs are [%s]", dbName, time.Since(start).Milliseconds(), "")
 	}
 
@@ -230,9 +227,6 @@ func (l *LevelDB) Commit(dbsUpdates map[string]*worldstate.DBUpdates, blockNumbe
 	binary.PutUvarint(b, blockNumber)
 	if err := db.file.Put(lastCommittedBlockNumberKey, b, db.writeOpts); err != nil {
 		return errors.Wrapf(err, "error while storing the last committed block number [%d] to the metadataDB", blockNumber)
-	}
-	if err := db.updateSnapshot(); err != nil {
-		return err
 	}
 
 	return nil
@@ -318,9 +312,6 @@ func (l *LevelDB) create(dbName string) error {
 		readOpts:  &opt.ReadOptions{},
 		writeOpts: &opt.WriteOptions{Sync: true},
 	}
-	if err := db.updateSnapshot(); err != nil {
-		return err
-	}
 
 	l.setDB(dbName, db)
 
@@ -336,9 +327,6 @@ func (l *LevelDB) delete(dbName string) error {
 		return nil
 	}
 
-	if db.snap != nil {
-		db.snap.Release()
-	}
 	if err := db.file.Close(); err != nil {
 		return errors.Wrapf(err, "error while closing the database [%s] before delete", dbName)
 	}

--- a/internal/worldstate/leveldb/commit_and_query.go
+++ b/internal/worldstate/leveldb/commit_and_query.go
@@ -25,30 +25,25 @@ var (
 
 // Exist returns true if the given database exist. Otherwise, it returns false.
 func (l *LevelDB) Exist(dbName string) bool {
-	l.dbsList.RLock()
-	defer l.dbsList.RUnlock()
-
-	_, ok := l.dbs[dbName]
+	_, ok := l.getDB(dbName)
 	return ok
 }
 
-// ListDBs list all user databases
+// ListDBs list all user databases. Used only for testing.
 func (l *LevelDB) ListDBs() []string {
-	l.dbsList.RLock()
-	defer l.dbsList.RUnlock()
-
 	dbsToExclude := make(map[string]struct{})
 	for _, name := range preCreateDBs {
 		dbsToExclude[name] = struct{}{}
 	}
 
 	var dbNames []string
-	for name := range l.dbs {
-		if _, ok := dbsToExclude[name]; ok {
-			continue
+	l.dbs.Range(func(key, value interface{}) bool {
+		name := key.(string)
+		if _, ok := dbsToExclude[name]; !ok {
+			dbNames = append(dbNames, name)
 		}
-		dbNames = append(dbNames, name)
-	}
+		return true
+	})
 
 	return dbNames
 }
@@ -56,18 +51,12 @@ func (l *LevelDB) ListDBs() []string {
 // Height returns the block height of the state database. In other words, it
 // returns the last committed block number
 func (l *LevelDB) Height() (uint64, error) {
-	l.dbsList.RLock()
-	defer l.dbsList.RUnlock()
-
-	db, ok := l.dbs[worldstate.MetadataDBName]
+	db, ok := l.getDB(worldstate.MetadataDBName)
 	if !ok {
 		return 0, errors.Errorf("unable to retrieve the state database height due to missing metadataDB")
 	}
 
-	db.mu.RLock()
-	defer db.mu.RUnlock()
-
-	blockNumberEnc, err := db.file.Get(lastCommittedBlockNumberKey, &opt.ReadOptions{})
+	blockNumberEnc, err := db.reader().Get(lastCommittedBlockNumberKey, db.readOpts)
 	if err != nil && err != leveldb.ErrNotFound {
 		return 0, errors.Wrap(err, "error while retrieving the state database height")
 	}
@@ -86,48 +75,38 @@ func (l *LevelDB) Height() (uint64, error) {
 
 // Get returns the value of the key present in the database.
 func (l *LevelDB) Get(dbName string, key string) ([]byte, *types.Metadata, error) {
-	l.dbsList.RLock()
-	defer l.dbsList.RUnlock()
-
-	db, ok := l.dbs[dbName]
+	db, ok := l.getDB(dbName)
 	if !ok {
 		return nil, nil, &DBNotFoundErr{
 			dbName: dbName,
 		}
 	}
 
-	peristed, err := l.cache.getState(dbName, key)
-	if err != nil {
-		return nil, nil, errors.WithMessagef(err, "failed to retrieve leveldb key [%s] from database %s through cache", key, dbName)
-	}
-	if peristed != nil {
-		return peristed.Value, peristed.Metadata, nil
-	}
+	dbVal, inCache := l.cache.getState(dbName, key)
+	if !inCache {
+		var err error
+		dbVal, err = db.reader().Get([]byte(key), db.readOpts)
+		if err == leveldb.ErrNotFound {
+			if err = l.cache.putState(dbName, key, nil); err != nil {
+				return nil, nil, err
+			}
+			return nil, nil, nil
+		}
+		if err != nil {
+			return nil, nil, errors.WithMessagef(err, "failed to retrieve leveldb key [%s] from database %s", key, dbName)
+		}
 
-	db.mu.RLock()
-	defer db.mu.RUnlock()
-
-	dbval, err := db.file.Get([]byte(key), db.readOpts)
-	if err == leveldb.ErrNotFound {
-		if err = l.cache.putState(dbName, key, nil); err != nil {
+		if err = l.cache.putState(dbName, key, dbVal); err != nil {
 			return nil, nil, err
 		}
-		return nil, nil, nil
-	}
-	if err != nil {
-		return nil, nil, errors.WithMessagef(err, "failed to retrieve leveldb key [%s] from database %s", key, dbName)
 	}
 
-	if err = l.cache.putState(dbName, key, dbval); err != nil {
+	value := &types.ValueWithMetadata{}
+	if err := proto.Unmarshal(dbVal, value); err != nil {
 		return nil, nil, err
 	}
 
-	persisted := &types.ValueWithMetadata{}
-	if err := proto.Unmarshal(dbval, persisted); err != nil {
-		return nil, nil, err
-	}
-
-	return persisted.Value, persisted.Metadata, nil
+	return value.Value, value.Metadata, nil
 }
 
 // GetVersion returns the version of the key present in the database
@@ -152,11 +131,11 @@ func (l *LevelDB) GetACL(dbName, key string) (*types.AccessControl, error) {
 
 // Has returns true if the key exist in the database
 func (l *LevelDB) Has(dbName, key string) (bool, error) {
-	l.dbsList.RLock()
-	db := l.dbs[dbName]
-	l.dbsList.RUnlock()
-
-	return db.file.Has([]byte(key), nil)
+	db, ok := l.getDB(dbName)
+	if !ok {
+		return false, nil
+	}
+	return db.reader().Has([]byte(key), db.readOpts)
 }
 
 // GetConfig returns the cluster configuration
@@ -184,11 +163,9 @@ func (l *LevelDB) GetIndexDefinition(dbName string) ([]byte, *types.Metadata, er
 // the caller wants from the first key in the database (lexicographic order). An empty
 // endKey (i.e., "") denotes that the caller wants till the last key in the database (lexicographic order).
 func (l *LevelDB) GetIterator(dbName string, startKey, endKey string) (worldstate.Iterator, error) {
-	l.dbsList.RLock()
-	db := l.dbs[dbName]
-	l.dbsList.RUnlock()
+	db, ok := l.getDB(dbName)
 
-	if db == nil {
+	if !ok || db == nil {
 		l.logger.Errorf("database %s does not exist", dbName)
 		return nil, errors.Errorf("database %s does not exist", dbName)
 	}
@@ -206,53 +183,51 @@ func (l *LevelDB) GetIterator(dbName string, startKey, endKey string) (worldstat
 		r.Limit = []byte(endKey)
 	}
 
-	return db.file.NewIterator(r, &opt.ReadOptions{}), nil
+	return db.reader().NewIterator(r, &opt.ReadOptions{}), nil
 }
 
 // Commit commits the updates to the database
 func (l *LevelDB) Commit(dbsUpdates map[string]*worldstate.DBUpdates, blockNumber uint64) error {
 	for dbName, updates := range dbsUpdates {
-		l.dbsList.RLock()
-		db := l.dbs[dbName]
-		l.dbsList.RUnlock()
-
-		if db == nil {
+		db, ok := l.getDB(dbName)
+		if !ok || db == nil {
 			l.logger.Errorf("database %s does not exist", dbName)
 			return errors.Errorf("database %s does not exist", dbName)
 		}
 
 		start := time.Now()
-		if err := l.commitToDB(dbName, db, updates); err != nil {
+		if err := l.commitToDB(db, updates); err != nil {
 			return err
 		}
-		l.logger.Debugf("changes committed to the database %s, took %d ms, available dbs are [%s]", dbName, time.Since(start).Milliseconds(), l.dbs)
+		if err := db.updateSnapshot(); err != nil {
+			return err
+		}
+		l.logger.Debugf("changes committed to the database %s, took %d ms, available dbs are [%s]", dbName, time.Since(start).Milliseconds(), "")
 	}
 
-	l.dbsList.RLock()
-	db, exists := l.dbs[worldstate.MetadataDBName]
-	l.dbsList.RUnlock()
-	if !exists {
-		l.logger.Errorf("metadata database does not exist, available dbs are [%+v]", l.dbs)
+	db, ok := l.getDB(worldstate.MetadataDBName)
+	if !ok {
+		l.logger.Errorf("metadata database does not exist, available dbs are [%+v]", "")
 		return errors.Errorf("metadata database does not exist")
 	}
 
-	db.mu.Lock()
-	defer db.mu.Unlock()
-
 	b := make([]byte, binary.MaxVarintLen64)
 	binary.PutUvarint(b, blockNumber)
-	if err := db.file.Put(lastCommittedBlockNumberKey, b, &opt.WriteOptions{}); err != nil {
+	if err := db.file.Put(lastCommittedBlockNumberKey, b, db.writeOpts); err != nil {
 		return errors.Wrapf(err, "error while storing the last committed block number [%d] to the metadataDB", blockNumber)
+	}
+	if err := db.updateSnapshot(); err != nil {
+		return err
 	}
 
 	return nil
 }
 
-func (l *LevelDB) commitToDB(dbName string, db *db, updates *worldstate.DBUpdates) error {
+func (l *LevelDB) commitToDB(db *Db, updates *worldstate.DBUpdates) error {
 	batch := &leveldb.Batch{}
 
 	for _, kv := range updates.Writes {
-		dbval, err := proto.Marshal(
+		dbVal, err := proto.Marshal(
 			&types.ValueWithMetadata{
 				Value:    kv.Value,
 				Metadata: kv.Metadata,
@@ -262,29 +237,26 @@ func (l *LevelDB) commitToDB(dbName string, db *db, updates *worldstate.DBUpdate
 			return errors.WithMessagef(err, "failed to marshal the constructed dbValue [%v]", kv.Value)
 		}
 
-		batch.Put([]byte(kv.Key), dbval)
-		l.cache.putStateIfExist(dbName, kv.Key, dbval)
+		batch.Put([]byte(kv.Key), dbVal)
+		l.cache.putStateIfExist(db.name, kv.Key, dbVal)
 	}
 
 	for _, key := range updates.Deletes {
 		batch.Delete([]byte(key))
-		l.cache.delState(dbName, key)
+		l.cache.delState(db.name, key)
 	}
-
-	db.mu.Lock()
-	defer db.mu.Unlock()
 
 	if err := db.file.Write(batch, db.writeOpts); err != nil {
 		return errors.Wrapf(err, "error while writing an update batch to database [%s]", db.name)
 	}
 
-	if dbName != worldstate.DatabasesDBName {
+	if db.name != worldstate.DatabasesDBName {
 		return nil
 	}
 
 	// if node fails during the creation or deletion of
 	// databases, during the recovery, these operations
-	// will be repeated again. Given that create() and
+	// will be repeated. Given that create() and
 	// delete() are a no-op when the db exist and not-exist,
 	// respectively, we don't need anything special to
 	// handle failures
@@ -293,15 +265,14 @@ func (l *LevelDB) commitToDB(dbName string, db *db, updates *worldstate.DBUpdate
 	// and delete list to be unique which is to be ensured
 	// by the validator.
 
-	for _, kv := range updates.Writes {
-		dbName := kv.Key
-		if err := l.create(dbName); err != nil {
+	for _, writeKV := range updates.Writes {
+		if err := l.create(writeKV.Key); err != nil {
 			return err
 		}
 	}
 
-	for _, dbName := range updates.Deletes {
-		if err := l.delete(dbName); err != nil {
+	for _, delDbName := range updates.Deletes {
+		if err := l.delete(delDbName); err != nil {
 			return err
 		}
 	}
@@ -311,25 +282,27 @@ func (l *LevelDB) commitToDB(dbName string, db *db, updates *worldstate.DBUpdate
 
 // create creates a database. It does not return an error when the database already exist.
 func (l *LevelDB) create(dbName string) error {
-	l.dbsList.Lock()
-	defer l.dbsList.Unlock()
-
-	if _, ok := l.dbs[dbName]; ok {
+	// The map is only updated in the methods create and delete, which are called on instance creation or commit.
+	// Both these operations are single threaded. So it is safe to check if db-name exists in the map before inserting.
+	// Note that this check is mandatory because trying to open an already opened DB will result in error.
+	if _, ok := l.getDB(dbName); ok {
 		l.logger.Debugf("Skipping %s cause database already exists", dbName)
 		return nil
 	}
 
+	// By default, this won't issue an error if the DB is missing nor if it exists
 	file, err := leveldb.OpenFile(filepath.Join(l.dbRootDir, dbName), &opt.Options{})
 	if err != nil {
 		return errors.WithMessagef(err, "failed to open leveldb file for database %s", dbName)
 	}
 
-	l.dbs[dbName] = &db{
+	// We assume no concurrent updates to the map due to the above, so we can use a blind store.
+	l.setDB(dbName, &Db{
 		name:      dbName,
 		file:      file,
 		readOpts:  &opt.ReadOptions{},
 		writeOpts: &opt.WriteOptions{Sync: true},
-	}
+	})
 
 	return nil
 }
@@ -338,22 +311,17 @@ func (l *LevelDB) create(dbName string) error {
 // delete would be called only by the Commit() when processing delete entries associated with
 // the _db
 func (l *LevelDB) delete(dbName string) error {
-	l.dbsList.Lock()
-	defer l.dbsList.Unlock()
-
-	db, ok := l.dbs[dbName]
-	if !ok {
+	db, loaded := l.getAndDelDB(dbName)
+	if !loaded {
 		return nil
 	}
 
-	db.mu.Lock()
-	defer db.mu.Unlock()
-
+	if db.snap != nil {
+		db.snap.Release()
+	}
 	if err := db.file.Close(); err != nil {
 		return errors.Wrapf(err, "error while closing the database [%s] before delete", dbName)
 	}
-
-	delete(l.dbs, dbName)
 
 	if err := os.RemoveAll(filepath.Join(l.dbRootDir, dbName)); err != nil {
 		return errors.Wrapf(err, "error while deleting database [%s]", dbName)

--- a/internal/worldstate/leveldb/open.go
+++ b/internal/worldstate/leveldb/open.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/opt"
+	"go.uber.org/multierr"
 )
 
 var (
@@ -30,20 +31,46 @@ var (
 // LevelDB holds information about all created database
 type LevelDB struct {
 	dbRootDir   string
-	dbs         map[string]*db
+	dbs         sync.Map
 	logger      *logger.SugarLogger
-	dbsList     sync.RWMutex
 	dbNameRegex *regexp.Regexp
 	cache       *cache
 }
 
-// db - a wrapper on an actual store
-type db struct {
+// Db - a wrapper on an actual store
+type Db struct {
 	name      string
 	file      *leveldb.DB
-	mu        sync.RWMutex
+	snap      *leveldb.Snapshot
 	readOpts  *opt.ReadOptions
 	writeOpts *opt.WriteOptions
+}
+
+type FileOrSnap interface {
+	leveldb.Reader
+	Has(key []byte, ro *opt.ReadOptions) (bool, error)
+}
+
+func (db *Db) reader() FileOrSnap {
+	if db.snap != nil {
+		return db.snap
+	} else {
+		return db.file
+	}
+}
+
+func (db *Db) updateSnapshot() error {
+	prev := db.snap
+	if prev != nil {
+		defer prev.Release()
+	}
+
+	if snap, err := db.file.GetSnapshot(); err != nil {
+		return err
+	} else {
+		db.snap = snap
+	}
+	return nil
 }
 
 var (
@@ -108,18 +135,9 @@ func openNewLevelDBInstance(c *Config) (*LevelDB, error) {
 		return nil, err
 	}
 
-	l := &LevelDB{
-		dbRootDir:   c.DBRootDir,
-		dbs:         make(map[string]*db),
-		logger:      c.Logger,
-		dbNameRegex: regexp.MustCompile(allowedCharsInDBName),
-		cache:       newCache(128),
-	}
-
-	for _, dbName := range preCreateDBs {
-		if err := l.create(dbName); err != nil {
-			return nil, err
-		}
+	l, err := openLevelDBInstance(c, preCreateDBs)
+	if err != nil {
+		return nil, err
 	}
 
 	if err := fileops.Remove(underCreationFlagPath); err != nil {
@@ -130,33 +148,25 @@ func openNewLevelDBInstance(c *Config) (*LevelDB, error) {
 }
 
 func openExistingLevelDBInstance(c *Config) (*LevelDB, error) {
-	l := &LevelDB{
-		dbRootDir:   c.DBRootDir,
-		dbs:         make(map[string]*db),
-		logger:      c.Logger,
-		dbNameRegex: regexp.MustCompile(allowedCharsInDBName),
-		cache:       newCache(128),
-	}
-
 	dbNames, err := fileops.ListSubdirs(c.DBRootDir)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "failed to retrieve existing level dbs from %s", c.DBRootDir)
 	}
 
-	for _, dbName := range dbNames {
-		file, err := leveldb.OpenFile(
-			filepath.Join(l.dbRootDir, dbName),
-			&opt.Options{ErrorIfMissing: false},
-		)
-		if err != nil {
-			return nil, errors.WithMessagef(err, "failed to open leveldb file for database %s", dbName)
-		}
+	return openLevelDBInstance(c, dbNames)
+}
 
-		l.dbs[dbName] = &db{
-			name:      dbName,
-			file:      file,
-			readOpts:  &opt.ReadOptions{},
-			writeOpts: &opt.WriteOptions{Sync: true},
+func openLevelDBInstance(c *Config, dbNames []string) (*LevelDB, error) {
+	l := &LevelDB{
+		dbRootDir:   c.DBRootDir,
+		logger:      c.Logger,
+		dbNameRegex: regexp.MustCompile(allowedCharsInDBName),
+		cache:       newCache(128),
+	}
+
+	for _, dbName := range dbNames {
+		if err := l.create(dbName); err != nil {
+			return nil, err
 		}
 	}
 
@@ -165,24 +175,56 @@ func openExistingLevelDBInstance(c *Config) (*LevelDB, error) {
 
 // Close closes the database instance by closing all leveldb databases
 func (l *LevelDB) Close() error {
-	l.dbsList.Lock()
-	defer l.dbsList.Unlock()
-
-	for name, db := range l.dbs {
-		db.mu.Lock()
-		defer db.mu.Unlock()
-
-		if err := db.file.Close(); err != nil {
-			return errors.Errorf("error while closing database %s, %v", name, err)
+	var aggErr []error
+	l.dbs.Range(func(name, value interface{}) bool {
+		db := value.(*Db)
+		if db.snap != nil {
+			db.snap.Release()
 		}
+		if err := db.file.Close(); err != nil {
+			aggErr = append(aggErr, errors.Wrapf(err, "error while closing database %s", name))
+		}
+		return true
+	})
+	l.dbs = sync.Map{}
 
-		delete(l.dbs, db.name)
+	if len(aggErr) > 0 {
+		return multierr.Combine(aggErr...)
 	}
-
 	return nil
 }
 
 // ValidDBName returns true if the given dbName is valid
 func (l *LevelDB) ValidDBName(dbName string) bool {
 	return l.dbNameRegex.MatchString(dbName)
+}
+
+func (l *LevelDB) getDB(name string) (*Db, bool) {
+	value, ok := l.dbs.Load(name)
+	if !ok {
+		return nil, ok
+	}
+	return value.(*Db), ok
+}
+
+func (l *LevelDB) getAndDelDB(name string) (*Db, bool) {
+	value, loaded := l.dbs.LoadAndDelete(name)
+	if !loaded {
+		return nil, loaded
+	}
+	return value.(*Db), loaded
+}
+
+func (l *LevelDB) setDB(name string, value *Db) {
+	l.dbs.Store(name, value)
+}
+
+// size is a costly operation. It is used only for testing.
+func (l *LevelDB) size() int {
+	sz := 0
+	l.dbs.Range(func(key, value interface{}) bool {
+		sz += 1
+		return true
+	})
+	return sz
 }

--- a/internal/worldstate/leveldb/open_test.go
+++ b/internal/worldstate/leveldb/open_test.go
@@ -17,10 +17,12 @@ func TestOpenLevelDBInstance(t *testing.T) {
 	assertDBInstance := func(dbRootDir string, l *LevelDB) {
 		require.NoFileExists(t, filepath.Join(dbRootDir, "undercreation"))
 		require.Equal(t, dbRootDir, l.dbRootDir)
-		require.Len(t, l.dbs, len(preCreateDBs))
+		require.Equal(t, l.size(), len(preCreateDBs))
 
 		for _, dbName := range preCreateDBs {
-			require.NotNil(t, l.dbs[dbName])
+			db, ok := l.getDB(dbName)
+			require.True(t, ok)
+			require.NotNil(t, db)
 		}
 
 		require.False(t, l.ValidDBName("db1/name"))
@@ -146,7 +148,8 @@ func TestOpenLevelDBInstance(t *testing.T) {
 
 		assertDBInstance(dbRootDir, l)
 
-		db := l.dbs[worldstate.DefaultDBName]
+		db, ok := l.getDB(worldstate.DefaultDBName)
+		require.True(t, ok)
 		err = db.file.Put([]byte("key1"), []byte("value1"), &opt.WriteOptions{Sync: true})
 		require.NoError(t, err)
 
@@ -160,7 +163,8 @@ func TestOpenLevelDBInstance(t *testing.T) {
 
 		assertDBInstance(dbRootDir, l)
 
-		db = l.dbs[worldstate.DefaultDBName]
+		db, ok = l.getDB(worldstate.DefaultDBName)
+		require.True(t, ok)
 		actualValue, err := db.file.Get([]byte("key1"), nil)
 		require.NoError(t, err)
 		require.Equal(t, []byte("value1"), actualValue)

--- a/internal/worldstate/leveldb/snapshot_test.go
+++ b/internal/worldstate/leveldb/snapshot_test.go
@@ -187,6 +187,5 @@ func deleteForSnapshotTest(t *testing.T, l *LevelDB) {
 	wdb, ok := l.getDB(worldstate.DatabasesDBName)
 	require.True(t, ok)
 	require.NoError(t, wdb.file.Delete([]byte("db1"), &opt.WriteOptions{Sync: true}))
-	require.NoError(t, wdb.updateSnapshot())
 	l.cache.delState(worldstate.DatabasesDBName, "db1")
 }

--- a/internal/worldstate/leveldb/snapshot_test.go
+++ b/internal/worldstate/leveldb/snapshot_test.go
@@ -49,7 +49,7 @@ func TestSnapshots(t *testing.T) {
 
 	// remove all kv pairs from the real db. As a result,
 	// the real db should not return any kv pairs while
-	// the snapshot s1 shoudl return the deleted kv pairs
+	// the snapshot s1 should return the deleted kv pairs
 	deleteForSnapshotTest(t, env.l)
 
 	verifyEmptiness(t, env.l)
@@ -184,8 +184,9 @@ func deleteForSnapshotTest(t *testing.T, l *LevelDB) {
 	}
 	require.NoError(t, l.Commit(u, 2))
 
-	l.dbsList.RLock()
-	l.dbs[worldstate.DatabasesDBName].file.Delete([]byte("db1"), &opt.WriteOptions{Sync: true})
+	wdb, ok := l.getDB(worldstate.DatabasesDBName)
+	require.True(t, ok)
+	require.NoError(t, wdb.file.Delete([]byte("db1"), &opt.WriteOptions{Sync: true}))
+	require.NoError(t, wdb.updateSnapshot())
 	l.cache.delState(worldstate.DatabasesDBName, "db1")
-	l.dbsList.RUnlock()
 }


### PR DESCRIPTION
- Replacing map with sync.Map
- Caching DB snapshot after commit to avoid creating a snapshot for each Get operation
- Modifying cache to return byte array to avoid code duplication
- Remove Db lock because levelDB is already protected
- Reduce code duplication in Open()

Signed-off-by: Liran Funaro <liran.funaro@gmail.com>