### PR TITLE
Cache last snapshot after commit

### DIFF
--- a/internal/worldstate/leveldb/open.go
+++ b/internal/worldstate/leveldb/open.go
@@ -41,8 +41,31 @@ type LevelDB struct {
 type Db struct {
 	name      string
 	file      *leveldb.DB
+	snap      *leveldb.Snapshot
+	reader    FileOrSnap
 	readOpts  *opt.ReadOptions
 	writeOpts *opt.WriteOptions
+}
+
+type FileOrSnap interface {
+	leveldb.Reader
+	Has(key []byte, ro *opt.ReadOptions) (bool, error)
+}
+
+func (db *Db) updateSnapshot() error {
+	prev := db.snap
+	if prev != nil {
+		defer prev.Release()
+	}
+
+	if snap, err := db.file.GetSnapshot(); err != nil {
+		db.reader = db.file
+		return errors.WithMessagef(err, "failed to create a leveldb snapshot for database %s", db.name)
+	} else {
+		db.snap = snap
+		db.reader = snap
+	}
+	return nil
 }
 
 var (
@@ -150,6 +173,9 @@ func (l *LevelDB) Close() error {
 	var aggErr []error
 	l.dbs.Range(func(name, value interface{}) bool {
 		db := value.(*Db)
+		if db.snap != nil {
+			db.snap.Release()
+		}
 		if err := db.file.Close(); err != nil {
 			aggErr = append(aggErr, errors.Wrapf(err, "error while closing database %s", name))
 		}

--- a/internal/worldstate/leveldb/snapshot_test.go
+++ b/internal/worldstate/leveldb/snapshot_test.go
@@ -187,5 +187,6 @@ func deleteForSnapshotTest(t *testing.T, l *LevelDB) {
 	wdb, ok := l.getDB(worldstate.DatabasesDBName)
 	require.True(t, ok)
 	require.NoError(t, wdb.file.Delete([]byte("db1"), &opt.WriteOptions{Sync: true}))
+	require.NoError(t, wdb.updateSnapshot())
 	l.cache.delState(worldstate.DatabasesDBName, "db1")
 }


### PR DESCRIPTION
- Caching DB snapshot after commit to avoid creating a snapshot for each Get operation